### PR TITLE
survival probabilities for Cox model

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
 URL: https://github.com/EmilHvitfeldt/censored
 BugReports: https://github.com/EmilHvitfeldt/censored/issues
 Remotes: 
-    tidymodels/parsnip
+    tidymodels/parsnip@9fef469
 Suggests: 
     testthat,
     glmnet,

--- a/R/aaa_survival_prop.R
+++ b/R/aaa_survival_prop.R
@@ -10,9 +10,8 @@
 #' @export
 cph_survival_prob <- function(x, new_data, .times, output = "surv", conf.int = .95, ...) {
   output <- match.arg(output, c("surv", "conf", "haz"))
-  new_data$.id <- seq_len(nrow(new_data))
-  y <- survival::survfit(x, newdata = new_data, id = .id,
-                         conf.int = conf.int, na.action = na.exclude, ...)
+  y <- survival::survfit(x, newdata = new_data, conf.int = conf.int,
+                         na.action = na.exclude, ...)
   res <-
     stack_survfit_cph(y, nrow(new_data)) %>%
     dplyr::group_nest(.row, .key = ".pred") %>%


### PR DESCRIPTION
Closes #36 

With the [recent change](https://github.com/therneau/survival/commit/98fefd045277a9fb726b0b03b3b8bb28fa252bd9#diff-7d27291cce45963171b08e8e13e3318cb424d181b2cc8ee19a1331d86c2761b8L126) for survival 3.2-8, us using the `id` arg of `survival::survfit.coxph()` in `cph_survival_prob()` is causing an error. According to the help page of `survival::survfit.coxph()`, "If newid is not present, then each individual row of newdata is presumed to represent a distinct subject." so I've removed it here.
