### PR TITLE
Require strata variable for predictions from a stratified Cox model

### DIFF
--- a/R/aaa_survival_prop.R
+++ b/R/aaa_survival_prop.R
@@ -104,3 +104,26 @@ km_with_cuts <- function(x, .times = NULL) {
   x$.cuts <- cut(x$.time, .times)
   x
 }
+
+cph_survival_pre <- function(new_data, object) {
+
+  # Check that the stratification variable is part of `new_data`.
+  # If this information is missing, survival::survfit() does not error but
+  # instead returns the survival curves for _all_ strata.
+  terms_x <- stats::terms(object$fit)
+  terms_special <- attr(terms_x, "specials")
+  has_strata <- !is.null(terms_special$strata)
+
+  if (has_strata) {
+    strata <- attr(terms_x, "term.labels")
+    strata <- grep(pattern = "^strata", x = strata, value = TRUE)
+    strata <- sub(pattern = "strata\\(", replacement = "", x = strata)
+    strata <- sub(pattern = "\\)", replacement = "", x = strata)
+
+    if (!strata %in% names(new_data)) {
+      rlang::abort("Please provide the strata variable in `new_data`.")
+    }
+  }
+
+  new_data
+}

--- a/R/proportional_hazards_data.R
+++ b/R/proportional_hazards_data.R
@@ -64,7 +64,7 @@ make_proportional_hazards_survival <- function() {
     mode = "censored regression",
     type = "time",
     value = list(
-      pre = NULL,
+      pre = cph_survival_pre,
       post = function(x, object) {
         unname(summary(x)$table[, "*rmean"])
       },
@@ -84,7 +84,7 @@ make_proportional_hazards_survival <- function() {
     mode = "censored regression",
     type = "survival",
     value = list(
-      pre = NULL,
+      pre = cph_survival_pre,
       post = NULL,
       func = c(pkg = "censored", fun = "cph_survival_prob"),
       args =

--- a/tests/testthat/test-proportional_hazards-survival.R
+++ b/tests/testthat/test-proportional_hazards-survival.R
@@ -37,6 +37,16 @@ test_that("time predictions", {
   expect_true(all(names(f_pred) == ".pred_time"))
   expect_equivalent(f_pred$.pred_time, unname(exp_f_pred))
   expect_equal(nrow(f_pred), nrow(lung))
+
+  # stratified model but no strata info
+  cox_model <- proportional_hazards() %>% set_engine("survival")
+  cox_fit_strata <- cox_model %>%
+    fit(Surv(time, status) ~ age + sex + wt.loss + strata(inst), data = lung)
+  new_data_0 <- data.frame(age = c(50, 60), sex = 1, wt.loss = 5)
+  expect_error(
+    predict(cox_fit_strata, new_data = new_data_0, type = "time"),
+    "provide the strata"
+  )
 })
 
 # ------------------------------------------------------------------------------
@@ -46,7 +56,7 @@ test_that("survival predictions", {
   expect_error(f_fit <- fit(cox_spec, Surv(time, status) ~ age + sex, data = lung), NA)
   expect_error(predict(f_fit, lung, type = "survival"),
                "When using 'type' values of 'survival' or 'hazard' are given")
-  # Test at observed event times since we use the step funciton and pec does not
+  # Test at observed event times since we use the step function and pec does not
   f_pred <- predict(f_fit, lung, type = "survival", .time = c(306, 455))
   exp_f_pred <- pec::predictSurvProb(exp_f_fit, lung, times = c(306, 455))
 
@@ -64,6 +74,16 @@ test_that("survival predictions", {
   expect_equal(
     tidyr::unnest(f_pred, cols = c(.pred))$.pred_survival,
     as.numeric(t(exp_f_pred))
+  )
+
+  # stratified model but no strata info
+  cox_model <- proportional_hazards() %>% set_engine("survival")
+  cox_fit_strata <- cox_model %>%
+    fit(Surv(time, status) ~ age + sex + wt.loss + strata(inst), data = lung)
+  new_data_0 <- data.frame(age = c(50, 60), sex = 1, wt.loss = 5)
+  expect_error(
+    predict(cox_fit_strata, new_data = new_data_0, type = "survival", .time = 200),
+    "provide the strata"
   )
 })
 


### PR DESCRIPTION
Closes  #42

``` r
library(survival)
library(censored)
#> Loading required package: parsnip

cox_model <- proportional_hazards() %>% 
  set_engine("survival")
cox_fit_strata <- cox_model %>% 
  fit(Surv(time, status) ~ age + sex + wt.loss + strata(inst), data = lung)

# no strata info given
new_data_0 <- data.frame(age = c(50, 60), sex = 1, wt.loss = 5)

# predictions should error informatively
predict(cox_fit_strata, new_data = new_data_0, type = "time") 
#> Error: Please provide the strata variable in `new_data`.
predict(cox_fit_strata, new_data = new_data_0, type = "survival", .time = 200) 
#> Error: Please provide the strata variable in `new_data`.
```

<sup>Created on 2021-03-31 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>