### PR TITLE
Rename `.time` to `time`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
 URL: https://github.com/tidymodels/censored
 BugReports: https://github.com/tidymodels/censored/issues
 Remotes: 
-    tidymodels/parsnip#493
+    tidymodels/parsnip
 Suggests: 
     testthat,
     glmnet,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R:
 Description: Bindings for additional models for use with the 'parsnip' package. 
 License: MIT + file LICENSE
 Depends:
-    parsnip (>= 0.1.5.9001),
+    parsnip (>= 0.1.5.9003),
     R (>= 2.10)
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
 URL: https://github.com/tidymodels/censored
 BugReports: https://github.com/tidymodels/censored/issues
 Remotes: 
-    tidymodels/parsnip
+    tidymodels/parsnip#493
 Suggests: 
     testthat,
     glmnet,

--- a/R/0_imports.R
+++ b/R/0_imports.R
@@ -18,7 +18,7 @@
 #' @importFrom generics fit
 
 utils::globalVariables(
-  c(".time", "object", "new_data", ".label", ".pred",
+  c("time", ".time", "object", "new_data", ".label", ".pred",
     ".cuts", ".id", ".pred_hazard_cumulative", ".tmp")
 )
 

--- a/R/bag_tree_ipred.R
+++ b/R/bag_tree_ipred.R
@@ -67,10 +67,10 @@ make_bag_tree_ipred <- function() {
     value = list(
       pre = NULL,
       post = function(x, object) {
-        .time <- object$spec$method$pred$survival$args$.time
-        res <- map(x, ~ summary(.x, times = pmin(.time, max(.x$time)))$surv)
-        res <- matrix(unlist(res), ncol = length(.time), byrow = TRUE)
-        matrix_to_nested_tibbles_survival(res, .time)
+        time <- object$spec$method$pred$survival$args$time
+        res <- map(x, ~ summary(.x, times = pmin(time, max(.x$time)))$surv)
+        res <- matrix(unlist(res), ncol = length(time), byrow = TRUE)
+        matrix_to_nested_tibbles_survival(res, time)
       },
       func = c(fun = "predict"),
       args =

--- a/R/boost_tree_data.R
+++ b/R/boost_tree_data.R
@@ -93,9 +93,9 @@ make_boost_tree_mboost <- function() {
     value = list(
       pre = NULL,
       post = function(x, object) {
-        .time <- object$spec$method$pred$survival$args$.time
-        res <- floor_surv_mboost(x, .time)
-        matrix_to_nested_tibbles_survival(res, .time)
+        time <- object$spec$method$pred$survival$args$time
+        res <- floor_surv_mboost(x, time)
+        matrix_to_nested_tibbles_survival(res, time)
       },
       func = c(pkg = "mboost", fun = "survFit"),
       args =
@@ -129,7 +129,7 @@ make_boost_tree_mboost <- function() {
 # the mboost::survFit isn't able to predict survival probabilities for a given
 # timepoint. This function rounds down to nearest timepoint and uses that
 # for prediction.
-floor_surv_mboost <- function(x, .time) {
-  ind <- purrr::map_int(.time, ~ max(which(.x > c(-Inf, unname(x$time)))))
+floor_surv_mboost <- function(x, time) {
+  ind <- purrr::map_int(time, ~ max(which(.x > c(-Inf, unname(x$time)))))
   t(unname(rbind(1, x$surv))[ind, ])
 }

--- a/R/decision_tree_data.R
+++ b/R/decision_tree_data.R
@@ -65,15 +65,15 @@ make_decision_tree_rpart <- function() {
     value = list(
       pre = NULL,
       post = function(x, object) {
-        .time <- object$spec$method$pred$survival$args$.time
-        matrix_to_nested_tibbles_survival(x, .time)
+        time <- object$spec$method$pred$survival$args$time
+        matrix_to_nested_tibbles_survival(x, time)
       },
       func = c(pkg = "pec", fun = "predictSurvProb"),
       args =
         list(
           object = quote(object$fit),
           newdata = quote(new_data),
-          times = rlang::expr(.time)
+          times = rlang::expr(time)
         )
     )
   )
@@ -136,15 +136,15 @@ make_decision_tree_party <- function() {
       pre = NULL,
       post = function(x, object) {
         x <- x[, -1, drop = FALSE]
-        .time <- object$spec$method$pred$survival$args$.time
-        matrix_to_nested_tibbles_survival(x, .time)
+        time <- object$spec$method$pred$survival$args$time
+        matrix_to_nested_tibbles_survival(x, time)
       },
       func = c(pkg = "pec", fun = "predictSurvProb"),
       args =
         list(
           object = quote(object$fit),
           newdata = quote(new_data),
-          times = rlang::expr(pmin(c(0, .time), max(object$fit$ctree@responses@variables)))
+          times = rlang::expr(pmin(c(0, time), max(object$fit$ctree@responses@variables)))
         )
     )
   )

--- a/R/misc.R
+++ b/R/misc.R
@@ -1,10 +1,10 @@
 # This function takes a matrix and turns it into list of nested tibbles
 # suitable for predict_survival
-matrix_to_nested_tibbles_survival <- function(x, .time) {
+matrix_to_nested_tibbles_survival <- function(x, time) {
 
   res <- tibble(
     .row = rep(seq_len(nrow(x)), each = ncol(x)),
-    .time = rep(.time, nrow(x)),
+    .time = rep(time, nrow(x)),
     .pred_survival = as.numeric(t(x))
   )
 

--- a/R/proportional_hazards_data.R
+++ b/R/proportional_hazards_data.R
@@ -91,7 +91,7 @@ make_proportional_hazards_survival <- function() {
         list(
           x = quote(object$fit),
           new_data = quote(new_data),
-          .times = rlang::expr(.time)
+          times = rlang::expr(time)
         )
     )
   )
@@ -198,7 +198,7 @@ make_proportional_hazards_glmnet <- function() {
         list(
           x = expr(object$fit),
           new_data = expr(new_data),
-          .times = expr(.time),
+          times = expr(time),
           s = expr(object$spec$args$penalty),
           training_data = expr(object$training_data)
         )

--- a/R/rand_forest_data.R
+++ b/R/rand_forest_data.R
@@ -67,15 +67,15 @@ make_rand_forest_party <- function() {
       pre = NULL,
       post = function(x, object) {
         x <- x[, -1, drop = FALSE]
-        .time <- object$spec$method$pred$survival$args$.time
-        matrix_to_nested_tibbles_survival(x, .time)
+        time <- object$spec$method$pred$survival$args$time
+        matrix_to_nested_tibbles_survival(x, time)
       },
       func = c(pkg = "pec", fun = "predictSurvProb"),
       args =
         list(
           object = quote(object$fit),
           newdata = quote(new_data),
-          times = rlang::expr(pmin(c(0, .time), max(object$fit$forest@responses@variables)))
+          times = rlang::expr(pmin(c(0, time), max(object$fit$forest@responses@variables)))
         )
     )
   )

--- a/README.Rmd
+++ b/README.Rmd
@@ -64,13 +64,13 @@ Here we see that the first patient is predicted to have `r round(predict(cox_mod
 
 ### survival
 
-When we specify `type = "survival"` then we are trying to get the probabilities of survival (not observing an event) up to a given time `.time`. 
+When we specify `type = "survival"` then we are trying to get the probabilities of survival (not observing an event) up to a given time `time`. 
 
 ```{r}
 pred_vals_survival <- predict(cox_mod, 
                               type = "survival", 
                               new_data = head(lung), 
-                              .time = c(100, 200))
+                              time = c(100, 200))
 
 pred_vals_survival
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ fitted on the `lung` data set.
 library(censored)
 #> Loading required package: parsnip
 library(survival)
+#> Warning: package 'survival' was built under R version 4.0.2
 
 cox_mod <-
   proportional_hazards() %>%
@@ -49,7 +50,7 @@ cox_mod <-
 cox_mod
 #> parsnip model object
 #> 
-#> Fit time:  23ms 
+#> Fit time:  13ms 
 #> Call:
 #> survival::coxph(formula = Surv(time, status) ~ age + ph.ecog, 
 #>     data = data, model = TRUE, x = TRUE)
@@ -89,24 +90,24 @@ left.
 
 When we specify `type = "survival"` then we are trying to get the
 probabilities of survival (not observing an event) up to a given time
-`.time`.
+`time`.
 
 ``` r
 pred_vals_survival <- predict(cox_mod, 
                               type = "survival", 
                               new_data = head(lung), 
-                              .time = c(100, 200))
+                              time = c(100, 200))
 
 pred_vals_survival
 #> # A tibble: 6 x 1
-#>   .pred               
-#>   <list>              
-#> 1 <tibble[,2] [2 × 2]>
-#> 2 <tibble[,2] [2 × 2]>
-#> 3 <tibble[,2] [2 × 2]>
-#> 4 <tibble[,2] [2 × 2]>
-#> 5 <tibble[,2] [2 × 2]>
-#> 6 <tibble[,2] [2 × 2]>
+#>   .pred           
+#>   <list>          
+#> 1 <tibble [2 × 2]>
+#> 2 <tibble [2 × 2]>
+#> 3 <tibble [2 × 2]>
+#> 4 <tibble [2 × 2]>
+#> 5 <tibble [2 × 2]>
+#> 6 <tibble [2 × 2]>
 
 pred_vals_survival$.pred[[1]]
 #> # A tibble: 2 x 2
@@ -152,7 +153,7 @@ For the proportional hazards model, the sign is reversed.
 | decision\_tree        | rpart    | TRUE     | FALSE        | TRUE  | FALSE    | FALSE  |
 | decision\_tree        | party    | TRUE     | FALSE        | TRUE  | FALSE    | FALSE  |
 | proportional\_hazards | survival | TRUE     | TRUE         | TRUE  | FALSE    | FALSE  |
-| proportional\_hazards | glmnet   | FALSE    | TRUE         | FALSE | FALSE    | FALSE  |
+| proportional\_hazards | glmnet   | TRUE     | TRUE         | FALSE | FALSE    | FALSE  |
 | rand\_forest          | party    | TRUE     | FALSE        | TRUE  | FALSE    | FALSE  |
 | survival\_reg         | survival | TRUE     | FALSE        | TRUE  | TRUE     | TRUE   |
 | survival\_reg         | flexsurv | TRUE     | FALSE        | TRUE  | TRUE     | TRUE   |

--- a/man/coxnet_survival_prob.Rd
+++ b/man/coxnet_survival_prob.Rd
@@ -4,14 +4,14 @@
 \alias{coxnet_survival_prob}
 \title{A wrapper for survival probabilities with coxnet models}
 \usage{
-coxnet_survival_prob(x, new_data, .times, training_data, output = "surv", ...)
+coxnet_survival_prob(x, new_data, times, training_data, output = "surv", ...)
 }
 \arguments{
 \item{x}{A model from \code{glmnet()}.}
 
 \item{new_data}{Data for prediction}
 
-\item{.times}{A vector of integers for prediction times.}
+\item{times}{A vector of integers for prediction times.}
 
 \item{training_data}{A list of \code{x} and \code{y} containing the training data.}
 

--- a/man/cph_survival_prob.Rd
+++ b/man/cph_survival_prob.Rd
@@ -4,14 +4,14 @@
 \alias{cph_survival_prob}
 \title{A wrapper for survival probabilities with cph models}
 \usage{
-cph_survival_prob(x, new_data, .times, output = "surv", conf.int = 0.95, ...)
+cph_survival_prob(x, new_data, times, output = "surv", conf.int = 0.95, ...)
 }
 \arguments{
 \item{x}{A model from \code{coxph()}.}
 
 \item{new_data}{Data for prediction}
 
-\item{.times}{A vector of integers for prediction times.}
+\item{times}{A vector of integers for prediction times.}
 
 \item{output}{One of "surv", "conf", or "haz".}
 

--- a/man/flexsurv_probs.Rd
+++ b/man/flexsurv_probs.Rd
@@ -6,18 +6,18 @@
 \alias{survreg_hazard_probs}
 \title{Internal function helps for parametric survival models}
 \usage{
-flexsurv_probs(object, new_data, .time, type = "survival")
+flexsurv_probs(object, new_data, time, type = "survival")
 
-survreg_survival_probs(object, new_data, .time)
+survreg_survival_probs(object, new_data, time)
 
-survreg_hazard_probs(object, new_data, .time)
+survreg_hazard_probs(object, new_data, time)
 }
 \arguments{
 \item{object}{A \code{survreg} or \code{flexsurvreg} object.}
 
 \item{new_data}{A data frame.}
 
-\item{.time}{A vector of time points}
+\item{time}{A vector of time points}
 }
 \value{
 A nested tibble with column name \code{.pred}

--- a/tests/testthat/test-bag_tree-ipred.R
+++ b/tests/testthat/test-bag_tree-ipred.R
@@ -54,7 +54,7 @@ test_that("survival predictions", {
   expect_error(f_fit <- fit(mod_spec, Surv(time, status) ~ age + ph.ecog, data = lung), NA)
   expect_error(predict(f_fit, lung, type = "survival"),
                "When using 'type' values of 'survival' or 'hazard' are given")
-  f_pred <- predict(f_fit, lung, type = "survival", .time = 100:200)
+  f_pred <- predict(f_fit, lung, type = "survival", time = 100:200)
   exp_f_pred <- map(predict(exp_f_fit, lung),
                     ~ summary(.x, times = c(100:200))$surv)
 
@@ -79,7 +79,7 @@ test_that("survival predictions", {
   )
 
   # Out of domain prediction
-  f_pred <- predict(f_fit, lung, type = "survival", .time = 10000)
+  f_pred <- predict(f_fit, lung, type = "survival", time = 10000)
   exp_f_pred <- map(predict(exp_f_fit, lung),
                     ~ summary(.x, times = c(max(.x$time)))$surv)
 

--- a/tests/testthat/test-boost_tree-mboost.R
+++ b/tests/testthat/test-boost_tree-mboost.R
@@ -37,7 +37,7 @@ test_that("survival predictions", {
   expect_error(f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung2), NA)
   expect_error(predict(f_fit, lung2, type = "survival"),
                "When using 'type' values of 'survival' or 'hazard' are given")
-  f_pred <- predict(f_fit, lung2, type = "survival", .time = pred_time)
+  f_pred <- predict(f_fit, lung2, type = "survival", time = pred_time)
   exp_f_pred <- mboost::survFit(exp_f_fit, lung2)
 
   expect_s3_class(f_pred, "tbl_df")

--- a/tests/testthat/test-decision_tree-party.R
+++ b/tests/testthat/test-decision_tree-party.R
@@ -48,7 +48,7 @@ test_that("survival predictions", {
   expect_error(f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung), NA)
   expect_error(predict(f_fit, lung, type = "survival"),
                "When using 'type' values of 'survival' or 'hazard' are given")
-  f_pred <- predict(f_fit, lung, type = "survival", .time = 100:200)
+  f_pred <- predict(f_fit, lung, type = "survival", time = 100:200)
   exp_f_pred <- pec::predictSurvProb(exp_f_fit, lung, times = 100:200)
 
   expect_s3_class(f_pred, "tbl_df")
@@ -72,7 +72,7 @@ test_that("survival predictions", {
   )
 
   # Out of domain prediction
-  f_pred <- predict(f_fit, lung, type = "survival", .time = 10000)
+  f_pred <- predict(f_fit, lung, type = "survival", time = 10000)
   exp_f_pred <- pec::predictSurvProb(exp_f_fit, lung, times = c(1, max(lung$time)))
 
   expect_equal(

--- a/tests/testthat/test-decision_tree-rpart.R
+++ b/tests/testthat/test-decision_tree-rpart.R
@@ -48,7 +48,7 @@ test_that("survival predictions", {
   expect_error(f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung), NA)
   expect_error(predict(f_fit, lung, type = "survival"),
                "When using 'type' values of 'survival' or 'hazard' are given")
-  f_pred <- predict(f_fit, lung, type = "survival", .time = 100:200)
+  f_pred <- predict(f_fit, lung, type = "survival", time = 100:200)
   exp_f_pred <- pec::predictSurvProb(exp_f_fit, lung, times = 100:200)
 
   expect_s3_class(f_pred, "tbl_df")

--- a/tests/testthat/test-proportional_hazards-glmnet.R
+++ b/tests/testthat/test-proportional_hazards-glmnet.R
@@ -145,12 +145,12 @@ test_that("survival probabilities - non-stratified model", {
 
   expect_error(
     pred_1 <- predict(f_fit, new_data = lung2[1, ], type = "survival",
-                      .time = c(100, 200)),
+                      time = c(100, 200)),
     NA
   )
 
   pred_2 <- predict(f_fit, new_data = lung2[1:2, ], type = "survival",
-                    .time = c(100, 200), penalty = 0.1)
+                    time = c(100, 200), penalty = 0.1)
 
   expect_s3_class(pred_2, "tbl_df")
   expect_equal(names(pred_2), ".pred")

--- a/tests/testthat/test-proportional_hazards-survival.R
+++ b/tests/testthat/test-proportional_hazards-survival.R
@@ -57,7 +57,7 @@ test_that("survival predictions", {
   expect_error(predict(f_fit, lung, type = "survival"),
                "When using 'type' values of 'survival' or 'hazard' are given")
   # Test at observed event times since we use the step function and pec does not
-  f_pred <- predict(f_fit, lung, type = "survival", .time = c(306, 455))
+  f_pred <- predict(f_fit, lung, type = "survival", time = c(306, 455))
   exp_f_pred <- pec::predictSurvProb(exp_f_fit, lung, times = c(306, 455))
 
   expect_s3_class(f_pred, "tbl_df")
@@ -82,7 +82,7 @@ test_that("survival predictions", {
     fit(Surv(time, status) ~ age + sex + wt.loss + strata(inst), data = lung)
   new_data_0 <- data.frame(age = c(50, 60), sex = 1, wt.loss = 5)
   expect_error(
-    predict(cox_fit_strata, new_data = new_data_0, type = "survival", .time = 200),
+    predict(cox_fit_strata, new_data = new_data_0, type = "survival", time = 200),
     "provide the strata"
   )
 })

--- a/tests/testthat/test-rand_forest-party.R
+++ b/tests/testthat/test-rand_forest-party.R
@@ -66,7 +66,7 @@ test_that("survival predictions", {
   )
   expect_error(predict(f_fit, lung, type = "survival"),
                "When using 'type' values of 'survival' or 'hazard' are given")
-  f_pred <- predict(f_fit, lung, type = "survival", .time = 100:200)
+  f_pred <- predict(f_fit, lung, type = "survival", time = 100:200)
   exp_f_pred <- pec::predictSurvProb(exp_f_fit, lung, times = 100:200)
 
   expect_s3_class(f_pred, "tbl_df")
@@ -91,7 +91,7 @@ test_that("survival predictions", {
   )
 
   # Out of domain prediction
-  f_pred <- predict(f_fit, lung, type = "survival", .time = 10000)
+  f_pred <- predict(f_fit, lung, type = "survival", time = 10000)
   exp_f_pred <- pec::predictSurvProb(exp_f_fit, lung, times = c(1, max(lung$time)))
 
   expect_equal(

--- a/tests/testthat/test_survival_reg_flexsurv.R
+++ b/tests/testthat/test_survival_reg_flexsurv.R
@@ -83,10 +83,10 @@ test_that("survival probability prediction", {
   )
   expect_error(
     predict(res, head(lung), type = "survival"),
-    "a numeric vector '.time'"
+    "a numeric vector 'time'"
   )
 
-  exp_pred <- predict(res, head(lung), type = "survival", .time = prob_times)
+  exp_pred <- predict(res, head(lung), type = "survival", time = prob_times)
   exp_pred_vert <- exp_pred %>% mutate(.patient = row_number()) %>% unnest(cols = .pred)
   expect_true(all(names(exp_pred) == ".pred"))
   expect_equal(names(exp_pred_vert), c(".time", ".pred_survival", ".patient"))
@@ -107,10 +107,10 @@ test_that("survival hazard prediction", {
   )
   expect_error(
     predict(res, head(lung), type = "hazard"),
-    "a numeric vector '.time'"
+    "a numeric vector 'time'"
   )
 
-  exp_pred <- predict(res, head(lung), type = "hazard", .time = prob_times)
+  exp_pred <- predict(res, head(lung), type = "hazard", time = prob_times)
   exp_pred_vert <- exp_pred %>% mutate(.patient = row_number()) %>% unnest(cols = .pred)
   expect_true(all(names(exp_pred) == ".pred"))
   expect_equal(names(exp_pred_vert), c(".time", ".pred_hazard", ".patient"))

--- a/tests/testthat/test_survival_reg_survival.R
+++ b/tests/testthat/test_survival_reg_survival.R
@@ -92,10 +92,10 @@ test_that("survival probability prediction", {
   )
   expect_error(
     predict(res, head(lung), type = "survival"),
-    "a numeric vector '.time'"
+    "a numeric vector 'time'"
   )
 
-  exp_pred <- predict(res, head(lung), type = "survival", .time = prob_times)
+  exp_pred <- predict(res, head(lung), type = "survival", time = prob_times)
   exp_pred_vert <- exp_pred %>% mutate(.patient = row_number()) %>% unnest(cols = .pred)
   expect_true(all(names(exp_pred) == ".pred"))
   expect_equal(names(exp_pred_vert), c(".time", ".pred_survival", ".patient"))
@@ -116,10 +116,10 @@ test_that("survival hazard prediction", {
   )
   expect_error(
     predict(res, head(lung), type = "hazard"),
-    "a numeric vector '.time'"
+    "a numeric vector 'time'"
   )
 
-  exp_pred <- predict(res, head(lung), type = "hazard", .time = prob_times)
+  exp_pred <- predict(res, head(lung), type = "hazard", time = prob_times)
   exp_pred_vert <- exp_pred %>% mutate(.patient = row_number()) %>% unnest(cols = .pred)
   expect_true(all(names(exp_pred) == ".pred"))
   expect_equal(names(exp_pred_vert), c(".time", ".pred_hazard", ".patient"))


### PR DESCRIPTION
Joint PR with https://github.com/tidymodels/parsnip/pull/493 (merge parsnip's PR, then remove the Remote on the PR and merge this one)

This PR renames `.time` to `time` everywhere it is used as a function argument. Output columns are still named `.time`, which is consistent with `.pred_*` columns that we return, and makes sense since it may be column binded with user data frames.