### PR TITLE
expect warning instead of error for `set_engine(NULL)`

### DIFF
--- a/tests/testthat/test_survival_reg.R
+++ b/tests/testthat/test_survival_reg.R
@@ -76,5 +76,6 @@ test_that("updating", {
 test_that("bad input", {
   expect_error(survival_reg(mode = ", classification"))
   expect_error(translate(survival_reg() %>% set_engine("wat")))
-  expect_error(translate(survival_reg() %>% set_engine(NULL)))
+  expect_warning(translate(survival_reg() %>% set_engine(NULL)),
+                 "`engine` was NULL and updated")
 })


### PR DESCRIPTION
updating the test to the new behaviour of parsnip which now issues a warning and sets the default engine