### PR TITLE
interpolate KM values per strata

### DIFF
--- a/R/0_imports.R
+++ b/R/0_imports.R
@@ -22,7 +22,7 @@ utils::globalVariables(
   c("time", ".time", "object", "new_data", ".label", ".pred",
     ".cuts", ".id", ".pred_hazard_cumulative", ".tmp", ".pred_survival",
     ".pred_survival_lower", ".pred_survival_upper", "engine",
-    "predictor_indicators")
+    "predictor_indicators", ".strata")
 )
 
 # ------------------------------------------------------------------------------

--- a/R/party.R
+++ b/R/party.R
@@ -82,7 +82,7 @@ cond_inference_surv_ctree <-
 
 approx_surv_fit <- function(x, .time = 0) {
   dat <- stack_survfit(x, n = 1)
-  interpolate_km_values(dat, .time)
+  interpolate_km_values_ungrouped(dat, .time)
 }
 
 #' @export

--- a/tests/testthat/test-proportional_hazards-glmnet.R
+++ b/tests/testthat/test-proportional_hazards-glmnet.R
@@ -180,17 +180,19 @@ test_that("survival probabilities - stratified model", {
     NA
   )
 
-  pred_2 <- predict(f_fit, new_data = bladder[1:2, ], type = "survival",
-                    time = c(5, 10), penalty = 0.1)
+  new_data_3 <- bladder[1:3, ]
+  f_pred <- predict(f_fit, new_data = new_data_3,
+                    type = "survival", time = c(10, 20))
 
-  expect_s3_class(pred_2, "tbl_df")
-  expect_equal(names(pred_2), ".pred")
-  expect_equal(nrow(pred_2), 2)
+  expect_s3_class(f_pred, "tbl_df")
+  expect_equal(names(f_pred), ".pred")
+  expect_equal(nrow(f_pred), nrow(new_data_3))
   expect_true(
-    all(purrr::map_lgl(pred_2$.pred, ~ all(dim(.x) == c(2, 2))))
+    all(purrr::map_lgl(f_pred$.pred,
+                       ~ all(dim(.x) == c(2, 2))))
   )
   expect_true(
-    all(purrr::map_lgl(pred_2$.pred,
+    all(purrr::map_lgl(f_pred$.pred,
                        ~ all(names(.x) == c(".time", ".pred_survival"))))
   )
 

--- a/tests/testthat/test-proportional_hazards-survival.R
+++ b/tests/testthat/test-proportional_hazards-survival.R
@@ -51,7 +51,7 @@ test_that("time predictions", {
 
 # ------------------------------------------------------------------------------
 
-test_that("survival predictions", {
+test_that("survival predictions - non-stratified", {
   # formula method
   expect_error(f_fit <- fit(cox_spec, Surv(time, status) ~ age + sex, data = lung), NA)
   expect_error(predict(f_fit, lung, type = "survival"),
@@ -75,14 +75,38 @@ test_that("survival predictions", {
     tidyr::unnest(f_pred, cols = c(.pred))$.pred_survival,
     as.numeric(t(exp_f_pred))
   )
+})
 
-  # stratified model but no strata info
-  cox_model <- proportional_hazards() %>% set_engine("survival")
-  cox_fit_strata <- cox_model %>%
-    fit(Surv(time, status) ~ age + sex + wt.loss + strata(inst), data = lung)
-  new_data_0 <- data.frame(age = c(50, 60), sex = 1, wt.loss = 5)
+test_that("survival predictions - stratified", {
+  cox_spec <- proportional_hazards() %>%
+    set_mode("censored regression") %>%
+    set_engine("survival")
+
+  set.seed(14)
+  f_fit <- fit(cox_spec,
+               Surv(stop, event) ~ rx + size + number + strata(enum),
+               data = bladder)
+
+  new_data_3 <- bladder[1:3, ]
+  f_pred <- predict(f_fit, new_data = new_data_3,
+                    type = "survival", time = c(10, 20))
+
+  expect_s3_class(f_pred, "tbl_df")
+  expect_equal(names(f_pred), ".pred")
+  expect_equal(nrow(f_pred), nrow(new_data_3))
+  expect_true(
+    all(purrr::map_lgl(f_pred$.pred,
+                       ~ all(dim(.x) == c(2, 2))))
+  )
+  expect_true(
+    all(purrr::map_lgl(f_pred$.pred,
+                       ~ all(names(.x) == c(".time", ".pred_survival"))))
+  )
+
+  # prediction without strata info should fail
+  new_data_s <- new_data_3 %>% dplyr::select(-enum)
   expect_error(
-    predict(cox_fit_strata, new_data = new_data_0, type = "survival", time = 200),
+    predict(f_fit, new_data = new_data_s, type = "survival", time = 20),
     "provide the strata"
   )
 })


### PR DESCRIPTION
Closes #63

The interpolation of the KM values for the survival probabilities needs to be done grouped by strata as the baseline curve varies across strata (and thus the event times used to generate the join column `.cuts`).

The example from the issue now has the correct dimensions: 

``` r
library(censored)
#> Loading required package: parsnip
library(survival)
library(tidyr)

# survival engine
spec_survival <- proportional_hazards() %>%
  set_mode("censored regression") %>%
  set_engine("survival")

set.seed(14)
fit_survival <- fit(spec_survival,
                    Surv(stop, event) ~ rx + size + number + strata(enum),
                    data = bladder)

pred_survival <- predict(fit_survival, new_data = bladder[1:2, ], 
                         type = "survival", time = c(10, 20))
pred_survival
#> # A tibble: 2 x 1
#>   .pred               
#>   <list>              
#> 1 <tibble[,2] [2 × 2]>
#> 2 <tibble[,2] [2 × 2]>
unnest(pred_survival, cols = c(".pred"))
#> # A tibble: 4 x 2
#>   .time .pred_survival
#>   <dbl>          <dbl>
#> 1    10          0.636
#> 2    20          0.519
#> 3    10          0.934
#> 4    20          0.726

# glmnet engine
spec_glmnet <- proportional_hazards(penalty = 0.123) %>%
  set_mode("censored regression") %>%
  set_engine("glmnet")

set.seed(14)
fit_glmnet <- fit(spec_glmnet,
                  Surv(stop, event) ~ rx + size + number + strata(enum),
                  data = bladder)

pred_glmnet <- predict(fit_glmnet, new_data = bladder[1:2, ], type = "survival",
                       time = c(10, 20), penalty = 0.1)
pred_glmnet
#> # A tibble: 2 x 1
#>   .pred               
#>   <list>              
#> 1 <tibble[,2] [2 × 2]>
#> 2 <tibble[,2] [2 × 2]>
unnest(pred_glmnet, cols = c(".pred"))
#> # A tibble: 4 x 2
#>   .time .pred_survival
#>   <dbl>          <dbl>
#> 1    10          0.623
#> 2    20          0.513
#> 3    10          0.929
#> 4    20          0.713
```

<sup>Created on 2021-06-16 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>