### PR TITLE
Fix interpolation of KM values

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -69,6 +69,8 @@ jobs:
         run: |
           pak::local_system_requirements(execute = TRUE)
           pak::pkg_system_requirements("rcmdcheck", execute = TRUE)
+          pak::pkg_system_requirements("textshaping", execute = TRUE)
+          pak::pkg_system_requirements("gert", execute = TRUE)
         shell: Rscript {0}
 
       - name: Install dependencies

--- a/R/aaa_survival_prop.R
+++ b/R/aaa_survival_prop.R
@@ -131,7 +131,7 @@ km_with_cuts <- function(x, times = NULL) {
   }
   times <- c(-Inf, times, Inf)
   times <- unique(times)
-  x$.cuts <- cut(x$.time, times)
+  x$.cuts <- cut(x$.time, times, right = FALSE)
   x
 }
 

--- a/tests/testthat/test-proportional_hazards-survival.R
+++ b/tests/testthat/test-proportional_hazards-survival.R
@@ -92,7 +92,10 @@ test_that("survival predictions - stratified", {
   new_data_3 <- bladder[1:3, ]
   f_pred <- predict(f_fit, new_data = new_data_3,
                     type = "survival", time = c(10, 20))
-  exp_f_pred <- pec::predictSurvProb(exp_f_fit, new_data_3, times = c(10, 20))
+  # reference value from pec::predictSurvProb()
+  exp_f_pred <- structure(c(0.635719137259774, 0.933929695867806, 0.967237940301564,
+                            0.534997251349036, 0.725922785669273, 0.904152770723571),
+                          .Dim = 3:2)
 
   expect_s3_class(f_pred, "tbl_df")
   expect_equal(names(f_pred), ".pred")

--- a/tests/testthat/test-proportional_hazards-survival.R
+++ b/tests/testthat/test-proportional_hazards-survival.R
@@ -86,10 +86,13 @@ test_that("survival predictions - stratified", {
   f_fit <- fit(cox_spec,
                Surv(stop, event) ~ rx + size + number + strata(enum),
                data = bladder)
+  exp_f_fit <- coxph(Surv(stop, event) ~ rx + size + number + strata(enum),
+                     data = bladder, x = TRUE)
 
   new_data_3 <- bladder[1:3, ]
   f_pred <- predict(f_fit, new_data = new_data_3,
                     type = "survival", time = c(10, 20))
+  exp_f_pred <- pec::predictSurvProb(exp_f_fit, new_data_3, times = c(10, 20))
 
   expect_s3_class(f_pred, "tbl_df")
   expect_equal(names(f_pred), ".pred")
@@ -101,6 +104,10 @@ test_that("survival predictions - stratified", {
   expect_true(
     all(purrr::map_lgl(f_pred$.pred,
                        ~ all(names(.x) == c(".time", ".pred_survival"))))
+  )
+  expect_equal(
+    tidyr::unnest(f_pred, cols = c(.pred))$.pred_survival,
+    as.numeric(t(exp_f_pred))
   )
 
   # prediction without strata info should fail


### PR DESCRIPTION
This closes  #67 by working with left-inclusive intervals for the steps of the KM curve. 

``` r
library(censored)
#> Loading required package: parsnip
library(survival)

cox_fit <- coxph(Surv(stop, event) ~ rx + size + number + strata(enum),
                   data = bladder, x = TRUE)

# predict survival prob at time 20 
new_data <- bladder[1:3, ]
times <- 20 

# from survival_prob_cph()
y <- survival::survfit(cox_fit, newdata = new_data, conf.int = 0.95)

stack_sf <- censored:::stack_survfit(y, nrow(new_data)) %>%
  # simplify to observation 1
  dplyr::filter(.row == 1) %>% 
  dplyr::bind_rows(censored:::prob_template, .)

# from interpolate_km_values_ungrouped()
stack_sf <- censored:::km_with_cuts(stack_sf)
# the two time points around 20
stack_sf %>% 
  dplyr::filter(18 <= .time & .time <= 22) %>% 
  dplyr::select(.time, .pred_survival, .row, .cuts)
#> # A tibble: 2 x 4
#>   .time .pred_survival  .row .cuts  
#>   <dbl>          <dbl> <int> <fct>  
#> 1    18          0.535     1 [18,22)
#> 2    22          0.519     1 [22,23)
# ^^ this are now cut with left-inclusive intervals and
# our join gives 0.535.
tibble::tibble(.time = times) %>%
  censored:::km_with_cuts(times = stack_sf$.time) %>%
  dplyr::rename(.tmp = .time) %>%
  dplyr::left_join(stack_sf, by = ".cuts") %>%
  dplyr::select(.time = .tmp, .cuts, .pred_survival)
#> # A tibble: 1 x 3
#>   .time .cuts   .pred_survival
#>   <dbl> <fct>            <dbl>
#> 1    20 [18,22)          0.535
```

<sup>Created on 2021-06-25 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>