### PR TITLE
fix `time` predictions for proportional hazards model with survival engine

### DIFF
--- a/R/proportional_hazards_data.R
+++ b/R/proportional_hazards_data.R
@@ -47,7 +47,7 @@ make_proportional_hazards_survival <- function() {
     value = list(
       pre = cph_survival_pre,
       post = function(x, object) {
-        unname(summary(x)$table[, "*rmean"])
+        unname(summary(x)$table[, "rmean"])
       },
       func = c(fun = "survfit"),
       args =

--- a/tests/testthat/test-proportional_hazards-survival.R
+++ b/tests/testthat/test-proportional_hazards-survival.R
@@ -31,7 +31,7 @@ test_that("time predictions", {
   # formula method
   expect_error(f_fit <- fit(cox_spec, Surv(time, status) ~ age + sex, data = lung), NA)
   f_pred <- predict(f_fit, lung, type = "time")
-  exp_f_pred <- unname(summary(survfit(exp_f_fit, lung, na.action = na.pass))$table[, "*rmean"])
+  exp_f_pred <- unname(summary(survfit(exp_f_fit, lung, na.action = na.pass))$table[, "rmean"])
 
   expect_s3_class(f_pred, "tbl_df")
   expect_true(all(names(f_pred) == ".pred_time"))


### PR DESCRIPTION
closes #75

this adapts {censored} to a column name change in {survival}