### PR TITLE
use glmnet helper functions from parsnip directly

### DIFF
--- a/R/proportional_hazards_data.R
+++ b/R/proportional_hazards_data.R
@@ -155,7 +155,7 @@ make_proportional_hazards_glmnet <- function() {
     type = "linear_pred",
     value = list(
       pre = coxnet_predict_pre,
-      post = organize_glmnet_pred,
+      post = parsnip::.organize_glmnet_pred,
       func = c(fun = "predict"),
       args =
         list(


### PR DESCRIPTION
Closes #62

use glmnet helper functions from parsnip directly now that they are exported