### PR TITLE
Linear pred sign change

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Depends:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1.9001
+RoxygenNote: 7.1.2
 Imports: 
     dials,
     dplyr (>= 0.8.0.1),

--- a/R/boost_tree_data.R
+++ b/R/boost_tree_data.R
@@ -113,7 +113,10 @@ make_boost_tree_mboost <- function() {
     type = "linear_pred",
     value = list(
       pre = NULL,
-      post = as.numeric,
+      post = function(x, object) {
+        # flip sign for consistency with other models
+        -as.numeric(x)
+        },
       func = c(fun = "predict"),
       args =
         list(

--- a/R/proportional_hazards_data.R
+++ b/R/proportional_hazards_data.R
@@ -155,7 +155,11 @@ make_proportional_hazards_glmnet <- function() {
     type = "linear_pred",
     value = list(
       pre = coxnet_predict_pre,
-      post = parsnip::.organize_glmnet_pred,
+      post = function(x, object) {
+        res <- parsnip::.organize_glmnet_pred(x, object)
+        # flip sign for consistency with other models
+        -res
+        },
       func = c(fun = "predict"),
       args =
         list(

--- a/tests/testthat/test-boost_tree-mboost.R
+++ b/tests/testthat/test-boost_tree-mboost.R
@@ -69,7 +69,7 @@ test_that("linear_pred predictions", {
   # formula method
   expect_error(f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung2), NA)
   f_pred <- predict(f_fit, lung2, type = "linear_pred")
-  exp_f_pred <- unname(predict(exp_f_fit, newdata = lung2))
+  exp_f_pred <- -unname(predict(exp_f_fit, newdata = lung2))
 
   expect_s3_class(f_pred, "tbl_df")
   expect_true(all(names(f_pred) == ".pred_linear_pred"))

--- a/tests/testthat/test-proportional_hazards-glmnet.R
+++ b/tests/testthat/test-proportional_hazards-glmnet.R
@@ -40,7 +40,7 @@ test_that("linear_pred predictions", {
 
   # predict
   f_pred <- predict(f_fit, lung2, type = "linear_pred", penalty = 0.01)
-  exp_f_pred <- unname(predict(exp_f_fit, newx = as.matrix(lung2[, c(4, 6)]), s = 0.01))
+  exp_f_pred <- -unname(predict(exp_f_fit, newx = as.matrix(lung2[, c(4, 6)]), s = 0.01))
 
   expect_s3_class(f_pred, "tbl_df")
   expect_true(all(names(f_pred) == ".pred_linear_pred"))
@@ -61,7 +61,8 @@ test_that("linear_pred predictions", {
       f_pred_unnested_01
     ) %>%
     dplyr::arrange(.row, penalty) %>%
-    dplyr::select(penalty, .pred_linear_pred)
+    dplyr::select(penalty, .pred_linear_pred) %>%
+    dplyr::mutate(.pred_linear_pred = -.pred_linear_pred)
 
   pred_multi <- multi_predict(f_fit, new_data_3, type = "linear_pred",
                               penalty = c(0.05, 0.1))


### PR DESCRIPTION
As part of the modelling workflow, we may want to use these predictions with a performance metric such as concordance. This metric captures the probability that the prediction goes in the same direction as the actual data. 

While the data captures _survival_ time, the linear predictor for a proportional hazards model is a factor on the _risk_. The predicted survival time is longer if the linear predictor is lower. 

To make the prediction and the observation go in the same direction, we flip the sign of the prediction. 

This is covering `proportional_hazards()` models with a `glmnet` engine and `boost_tree()` models with an `mboost` engine for #21 .