### PR TITLE
Consistent predictions of type `linear_pred` for `proportional_hazards()` models

### DIFF
--- a/R/proportional_hazards_data.R
+++ b/R/proportional_hazards_data.R
@@ -94,7 +94,8 @@ make_proportional_hazards_survival <- function() {
         list(
           object = quote(object$fit),
           newdata = quote(new_data),
-          na.action = quote(stats::na.exclude)
+          na.action = quote(stats::na.exclude),
+          reference = "zero"
         )
     )
   )

--- a/tests/testthat/test-proportional_hazards-survival.R
+++ b/tests/testthat/test-proportional_hazards-survival.R
@@ -127,7 +127,7 @@ test_that("linear_pred predictions", {
   # formula method
   expect_error(f_fit <- fit(cox_spec, Surv(time, status) ~ age + sex, data = lung), NA)
   f_pred <- predict(f_fit, lung, type = "linear_pred")
-  exp_f_pred <- -unname(predict(exp_f_fit, newdata = lung))
+  exp_f_pred <- -unname(predict(exp_f_fit, newdata = lung, reference = "zero"))
 
   expect_s3_class(f_pred, "tbl_df")
   expect_true(all(names(f_pred) == ".pred_linear_pred"))


### PR DESCRIPTION
Unlike glmnet and mboost, the survial package has a default to center the covariates when calculating the linear predictor. Setting `reference = "zero"` for `predict.coxph()` gives the linear predictor without that centering.

This PR let's predictions returned by censored to be calculated without that centering, regardless of which engine is used, ie. predictions from the `survival` engine are now _not_ centered.


``` r
library(survival)
library(ggplot2)
library(dplyr)
library(tidyr)
library(prodlim)
set.seed(43500)

# add 0.5 to X2 (with mean 0) to demonstrate the effect of centering
train_dat <- SimSurv(2000) %>% mutate(X2 = X2 + 0.5)
test_dat <- SimSurv(20) %>% mutate(X2 = X2 + 0.5)
test_pred <- test_dat[, 5:6]


fit_survival <- coxph(Surv(time, status) ~ X1 + X2, data = train_dat)
pred_survival <- predict(fit_survival, newdata = test_pred)
pred_survival_noncentered <- predict(fit_survival, newdata = test_pred, reference = "zero")

pred <- bind_cols(
  # both predictors have an effect of 1
  test_pred %>% mutate(linear_pred = X1 * 1  + X2 * 1), 
  tibble(pred_centered = pred_survival),
  tibble(pred_noncentered = pred_survival_noncentered)
)

mean(train_dat$X2)
#> [1] 0.4683339

pred %>% 
  pivot_longer(cols = starts_with("pred_"), names_to = "type", values_to = "pred") %>% 
  ggplot(aes(linear_pred, pred, col = type)) + 
  geom_point() +
  geom_abline(slope = 1, intercept = 0) +
  scale_color_discrete("survival arg `reference`", labels = c("default", "zero"))
```

![](https://i.imgur.com/jHy0s1J.png)

<sup>Created on 2021-09-27 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>