### PR TITLE
avoid nesting when using bind_rows()

### DIFF
--- a/R/aaa_survival_prop.R
+++ b/R/aaa_survival_prop.R
@@ -213,9 +213,7 @@ survival_prob_coxnet <- function(object, new_data, times, output = "surv", penal
       dplyr::distinct(.row) %>%
       dplyr::bind_cols(prob_template)
   }
-  res <- stacked_distinct %>%
-    dplyr::bind_cols(prob_template) %>%
-    dplyr::bind_rows(stacked_survfit) %>%
+  res <- dplyr::bind_rows(starting_rows, stacked_survfit) %>%
     interpolate_km_values(times, new_strata) %>%
     keep_cols(output, keep_penalty) %>%
     tidyr::nest(.pred = c(-.row)) %>%


### PR DESCRIPTION
This PR closes https://github.com/tidymodels/censored/issues/72.
It gains speedup by replacing `group_nest() %>% mutate(map(bind_rows)) %>% unnest()` with `distinct() %>% bind_cols() %>% bind_rows()` giving equivalent(row-invariant) results.
 
New benchmarking:

``` r
library(censored)
#> Loading required package: parsnip
library(survival)

spec_g <- proportional_hazards(penalty = 0.123) %>% 
  set_engine("glmnet")

fit_g <- fit(spec_g, 
             Surv(stop, event) ~ rx + size + number + strata(enum),
             data = bladder)

new_data_3 <- bladder[rep(1:3, 10000), ]

tictoc::tic()
mp_s <- multi_predict(fit_g, new_data_3, penalty = c(0.05, 0.1),
                    type = "survival", time = c(5, 10))
tictoc::toc()
#> 5.033 sec elapsed
```

Old Benchmarking:

``` r
library(censored)
#> Loading required package: parsnip
library(survival)

spec_g <- proportional_hazards(penalty = 0.123) %>% 
  set_engine("glmnet")

fit_g <- fit(spec_g, 
             Surv(stop, event) ~ rx + size + number + strata(enum),
             data = bladder)

new_data_3 <- bladder[rep(1:3, 10000), ]

tictoc::tic()
mp_s <- multi_predict(fit_g, new_data_3, penalty = c(0.05, 0.1),
                    type = "survival", time = c(5, 10))
tictoc::toc()
#> 12.428 sec elapsed
```

And profiling of the affected code is equally promising

New:
<img width="969" alt="Screen Shot 2021-10-19 at 4 15 35 PM" src="https://user-images.githubusercontent.com/14034784/138005376-b3a02d3a-009b-4c1b-a6c5-5721bc9f842e.png">

Old:
<img width="963" alt="Screen Shot 2021-10-19 at 4 15 49 PM" src="https://user-images.githubusercontent.com/14034784/138005378-62b904b7-974a-47c8-925e-46dbca4831be.png">


