### PR TITLE
Fix format of `quantile` predictions for `survival_reg()` with the `flexsurv` engine

### DIFF
--- a/R/survival_reg.R
+++ b/R/survival_reg.R
@@ -35,7 +35,12 @@ flexsurv_mean <- function(results, object) {
 flexsurv_quant <- function(results, object) {
   results <- purrr::map(results, as_tibble)
   names(results) <- NULL
-  results <- purrr::map(results, setNames, c(".quantile", ".pred", ".pred_lower", ".pred_upper"))
+  results <- purrr::map(
+    results,
+    setNames,
+    c(".quantile", ".pred_quantile", ".pred_quantile_lower", ".pred_quantile_upper")
+    )
+  tibble(.pred = results)
 }
 
 #' Internal function helps for parametric survival models

--- a/man/details_bag_tree_rpart.Rd
+++ b/man/details_bag_tree_rpart.Rd
@@ -4,7 +4,7 @@
 \alias{details_bag_tree_rpart}
 \title{Ensembles of CART decision trees}
 \description{
-\code{\link[ipred:bagging]{ipred::bagging()}} fits an ensemble of decision trees.
+\code{\link[ipred:bagging]{ipred::bagging()}} fits an ensemble of decision trees, using the \code{rpart} package.
 }
 \details{
 For this engine, there is a single mode: censored regression


### PR DESCRIPTION
Closes #99

``` r
library(censored)
#> Loading required package: parsnip
library(survival)

fit_s <- survival_reg() %>% 
  set_engine("flexsurv") %>% 
  set_mode("censored regression") %>% 
  fit(Surv(stop, event) ~ rx + size + enum, data = bladder)

pred <- predict(fit_s, new_data = bladder[1:3,], type = "quantile")
pred
#> # A tibble: 3 × 1
#>   .pred           
#>   <list>          
#> 1 <tibble [9 × 4]>
#> 2 <tibble [9 × 4]>
#> 3 <tibble [9 × 4]>
pred$.pred[[1]]
#> # A tibble: 9 × 4
#>   .quantile .pred_quantile .pred_quantile_lower .pred_quantile_upper
#>       <dbl>          <dbl>                <dbl>                <dbl>
#> 1       0.1           3.57                 2.22                 5.67
#> 2       0.2           7.33                 4.92                10.9 
#> 3       0.3          11.5                  8.00                16.2 
#> 4       0.4          16.2                 11.6                 22.5 
#> 5       0.5          21.7                 15.7                 29.7 
#> 6       0.6          28.3                 20.3                 39.0 
#> 7       0.7          36.8                 26.5                 51.1 
#> 8       0.8          48.5                 35.0                 68.1 
#> 9       0.9          68.4                 48.3                 97.8
```

<sup>Created on 2021-11-03 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>