### PR TITLE
shorten readme

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -49,11 +49,11 @@ nope <- cli::symbol$cross
 
 mod_names <- get_from_env("models")
 model_info <-
-  map_dfr(mod_names, ~ get_from_env(paste0(.x, "_predict")) %>% mutate(alias = .x))
+  map_dfr(mod_names, ~ get_from_env(paste0(.x, "_predict")) %>% mutate(model = .x))
 
 model_info %>%
   filter(mode == "censored regression") %>%
-  select(model = alias, engine, mode, type, -value) %>%
+  select(model, engine, mode, type) %>%
   pivot_wider(names_from = type, 
               values_from = mode, 
               values_fill = nope, 

--- a/README.Rmd
+++ b/README.Rmd
@@ -33,7 +33,7 @@ devtools::install_github("tidymodels/censored")
 
 ## Available models, engines, and prediction types 
 
-censored provides engines for the models in the following table. 
+censored provides engines for the models in the following table. For examples, please see [Fitting and Predicting with censored](https://censored.tidymodels.org/articles/articles/examples.html).
 
 The time to event can be predicted with `type = "time"`, the 
 survival probability with `type = "survival"`, the linear predictor with `type = "linear_pred"`, the quantiles of the event time distribution with `type = "quantile"`, and the hazard with `type = "hazard"`.

--- a/README.Rmd
+++ b/README.Rmd
@@ -31,7 +31,7 @@ This package is still in development. You can install the development version wi
 devtools::install_github("tidymodels/censored")
 ```
 
-# Available models, engines, and prediction types 
+## Available models, engines, and prediction types 
 
 censored provides engines for the models in the following table. 
 
@@ -60,3 +60,15 @@ model_info %>%
               values_fn = function(x) yep) %>%
   knitr::kable()
 ```
+
+## Contributing
+
+This project is released with a [Contributor Code of Conduct](https://contributor-covenant.org/version/2/0/CODE_OF_CONDUCT.html). By contributing to this project, you agree to abide by its terms.
+
+- For questions and discussions about tidymodels packages, modeling, and machine learning, please [post on RStudio Community](https://community.rstudio.com/new-topic?category_id=15&tags=tidymodels,question).
+
+- If you think you have encountered a bug, please [submit an issue](https://github.com/tidymodels/censored/issues).
+
+- Either way, learn how to create and share a [reprex](https://reprex.tidyverse.org/articles/articles/learn-reprex.html) (a minimal, reproducible example), to clearly communicate about your code.
+
+- Check out further details on [contributing guidelines for tidymodels packages](https://www.tidymodels.org/contribute/) and [how to get help](https://www.tidymodels.org/help/).

--- a/README.Rmd
+++ b/README.Rmd
@@ -17,100 +17,46 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![R-CMD-check](https://github.com/tidymodels/censored/workflows/R-CMD-check/badge.svg)](https://github.com/tidymodels/censored/actions)
-[![Codecov test coverage](https://codecov.io/gh/EmilHvitfeldt/censored/branch/main/graph/badge.svg)](https://codecov.io/gh/EmilHvitfeldt/censored?branch=main)
+[![Codecov test coverage](https://codecov.io/gh/tidymodels/censored/branch/main/graph/badge.svg)](https://codecov.io/gh/tidymodels/censored?branch=main)
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/#experimental) 
-
 <!-- badges: end -->
 
-`censored` is a "`parsnip`-adjacent" packages with
-model definitions for censored regression and survival analysis models.
+`censored` is a [parsnip](https://parsnip.tidymodels.org) extension package which provides engines for various models for censored regression and survival analysis.
 
 ## Installation
 
-This package is still in early development. You need to install the development version of parsnip as well.
+This package is still in development. You can install the development version with
 
 ``` {.r}
-# install.packages("pak")
-pak::pak("tidymodels/censored")
+devtools::install_github("tidymodels/censored")
 ```
 
-## Prediction Types
+# Available models, engines, and prediction types 
 
-The addition of censored regression comes with changes. One of these changes is the quantities we would like to predict from the model. The three quantities we will consider are: `"time"`, `"survival"`, and `"linear_pred"`.
+censored provides engines for the models in the following table. 
 
-To showcase these the differences, here is a simple Cox regression model fitted on the `lung` data set.
-
-```{r}
-library(censored)
-library(survival)
-
-cox_mod <-
-  proportional_hazards() %>%
-  set_engine("survival") %>%
-  fit(Surv(time, status) ~ age + ph.ecog, data = lung)
-
-cox_mod
-```
-
-### time
-
-When we specify `type = "time"` then we get back the predicted survival time of an observation based on its predictors. The survival time is the time it takes for the observation to observe an event.
-
-```{r}
-predict(cox_mod, type = "time", new_data = head(lung))
-```
-
-Here we see that the first patient is predicted to have `r round(predict(cox_mod, type = "time", new_data = lung)$.pred_time[1], 2)` days left.
-
-### survival
-
-When we specify `type = "survival"` then we are trying to get the probabilities of survival (not observing an event) up to a given time `time`. 
-
-```{r}
-pred_vals_survival <- predict(cox_mod, 
-                              type = "survival", 
-                              new_data = head(lung), 
-                              time = c(100, 200))
-
-pred_vals_survival
-
-pred_vals_survival$.pred[[1]]
-```
-
-here we see that the first patient has a `r round(pred_vals_survival$.pred[[1]]$.pred_survival[1], 3) * 100`% probability of survival up to 100 days and `r round(pred_vals_survival$.pred[[1]]$.pred_survival[2], 3) * 100`%
-probability of survival up to 200 days.
-
-### linear_pred
-
-when we specify `type = "linear_pred"` then we get back the linear predictor for the observation according to the model.
-
-```{r}
-predict(cox_mod, type = "linear_pred", new_data = head(lung))
-```
-
-here we see that the linear predictor of the first observation is  `r round(predict(cox_mod, type = "linear_pred", new_data = lung)$.pred_linear_pred[1], 4)`.
-
-Note that, for linear predictor prediction types, the results are formatted for all models such that the prediction _increases_ with time. For the proportional hazards model, the sign is reversed. 
-
-
-## Prediction type table 
+The time to event can be predicted with `type = "time"`, the 
+survival probability with `type = "survival"`, the linear predictor with `type = "linear_pred"`, the quantiles of the event time distribution with `type = "quantile"`, and the hazard with `type = "hazard"`.
 
 ```{r, echo=FALSE, message=FALSE}
 library(censored)
 library(dplyr)
 library(purrr)
 library(tidyr)
+
+yep <- cli::symbol$tick
+nope <- cli::symbol$cross
+
 mod_names <- get_from_env("models")
 model_info <-
   map_dfr(mod_names, ~ get_from_env(paste0(.x, "_predict")) %>% mutate(alias = .x))
 
 model_info %>%
   filter(mode == "censored regression") %>%
-  select(alias, engine, mode, type, -value) %>%
+  select(model = alias, engine, mode, type, -value) %>%
   pivot_wider(names_from = type, 
               values_from = mode, 
-              values_fill = FALSE, 
-              values_fn = function(x) TRUE) %>%
+              values_fill = nope, 
+              values_fn = function(x) yep) %>%
   knitr::kable()
 ```
-

--- a/README.md
+++ b/README.md
@@ -7,153 +7,41 @@
 
 [![R-CMD-check](https://github.com/tidymodels/censored/workflows/R-CMD-check/badge.svg)](https://github.com/tidymodels/censored/actions)
 [![Codecov test
-coverage](https://codecov.io/gh/EmilHvitfeldt/censored/branch/main/graph/badge.svg)](https://codecov.io/gh/EmilHvitfeldt/censored?branch=main)
+coverage](https://codecov.io/gh/tidymodels/censored/branch/main/graph/badge.svg)](https://codecov.io/gh/tidymodels/censored?branch=main)
 [![Lifecycle:
 experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/#experimental)
-
 <!-- badges: end -->
 
-`censored` is a “`parsnip`-adjacent” packages with model definitions for
-censored regression and survival analysis models.
+`censored` is a [parsnip](https://parsnip.tidymodels.org) extension
+package which provides engines for various models for censored
+regression and survival analysis.
 
 ## Installation
 
-This package is still in early development. You need to install the
-development version of parsnip as well.
+This package is still in development. You can install the development
+version with
 
 ``` r
-# install.packages("pak")
-pak::pak("tidymodels/censored")
+devtools::install_github("tidymodels/censored")
 ```
 
-## Prediction Types
+# Available models, engines, and prediction types
 
-The addition of censored regression comes with changes. One of these
-changes is the quantities we would like to predict from the model. The
-three quantities we will consider are: `"time"`, `"survival"`, and
-`"linear_pred"`.
+censored provides engines for the models in the following table.
 
-To showcase these the differences, here is a simple Cox regression model
-fitted on the `lung` data set.
+The time to event can be predicted with `type = "time"`, the survival
+probability with `type = "survival"`, the linear predictor with
+`type = "linear_pred"`, the quantiles of the event time distribution
+with `type = "quantile"`, and the hazard with `type = "hazard"`.
 
-``` r
-library(censored)
-#> Loading required package: parsnip
-library(survival)
-
-cox_mod <-
-  proportional_hazards() %>%
-  set_engine("survival") %>%
-  fit(Surv(time, status) ~ age + ph.ecog, data = lung)
-
-cox_mod
-#> parsnip model object
-#> 
-#> Fit time:  12ms 
-#> Call:
-#> survival::coxph(formula = Surv(time, status) ~ age + ph.ecog, 
-#>     data = data, model = TRUE, x = TRUE)
-#> 
-#>             coef exp(coef) se(coef)     z        p
-#> age     0.011281  1.011345 0.009319 1.211 0.226082
-#> ph.ecog 0.443485  1.558128 0.115831 3.829 0.000129
-#> 
-#> Likelihood ratio test=19.06  on 2 df, p=7.279e-05
-#> n= 227, number of events= 164 
-#>    (1 observation deleted due to missingness)
-```
-
-### time
-
-When we specify `type = "time"` then we get back the predicted survival
-time of an observation based on its predictors. The survival time is the
-time it takes for the observation to observe an event.
-
-``` r
-predict(cox_mod, type = "time", new_data = head(lung))
-#> # A tibble: 6 × 1
-#>   .pred_time
-#>        <dbl>
-#> 1       342.
-#> 2       474.
-#> 3       511.
-#> 4       389.
-#> 5       498.
-#> 6       342.
-```
-
-Here we see that the first patient is predicted to have 342.36 days
-left.
-
-### survival
-
-When we specify `type = "survival"` then we are trying to get the
-probabilities of survival (not observing an event) up to a given time
-`time`.
-
-``` r
-pred_vals_survival <- predict(cox_mod, 
-                              type = "survival", 
-                              new_data = head(lung), 
-                              time = c(100, 200))
-
-pred_vals_survival
-#> # A tibble: 6 × 1
-#>   .pred           
-#>   <list>          
-#> 1 <tibble [2 × 2]>
-#> 2 <tibble [2 × 2]>
-#> 3 <tibble [2 × 2]>
-#> 4 <tibble [2 × 2]>
-#> 5 <tibble [2 × 2]>
-#> 6 <tibble [2 × 2]>
-
-pred_vals_survival$.pred[[1]]
-#> # A tibble: 2 × 2
-#>   .time .pred_survival
-#>   <dbl>          <dbl>
-#> 1   100          0.855
-#> 2   200          0.649
-```
-
-here we see that the first patient has a 85.5% probability of survival
-up to 100 days and 64.9% probability of survival up to 200 days.
-
-### linear\_pred
-
-when we specify `type = "linear_pred"` then we get back the linear
-predictor for the observation according to the model.
-
-``` r
-predict(cox_mod, type = "linear_pred", new_data = head(lung))
-#> # A tibble: 6 × 1
-#>   .pred_linear_pred
-#>               <dbl>
-#> 1            -1.28 
-#> 2            -0.767
-#> 3            -0.632
-#> 4            -1.09 
-#> 5            -0.677
-#> 6            -1.28
-```
-
-here we see that the linear predictor of the first observation is
--1.2783.
-
-Note that, for linear predictor prediction types, the results are
-formatted for all models such that the prediction *increases* with time.
-For the proportional hazards model, the sign is reversed.
-
-## Prediction type table
-
-| alias                 | engine   | time  | survival | linear\_pred | raw   | quantile | hazard |
-|:----------------------|:---------|:------|:---------|:-------------|:------|:---------|:-------|
-| bag\_tree             | rpart    | TRUE  | TRUE     | FALSE        | FALSE | FALSE    | FALSE  |
-| boost\_tree           | mboost   | FALSE | TRUE     | TRUE         | FALSE | FALSE    | FALSE  |
-| decision\_tree        | rpart    | TRUE  | TRUE     | FALSE        | FALSE | FALSE    | FALSE  |
-| decision\_tree        | party    | TRUE  | TRUE     | FALSE        | FALSE | FALSE    | FALSE  |
-| proportional\_hazards | survival | TRUE  | TRUE     | TRUE         | FALSE | FALSE    | FALSE  |
-| proportional\_hazards | glmnet   | FALSE | TRUE     | TRUE         | TRUE  | FALSE    | FALSE  |
-| rand\_forest          | party    | TRUE  | TRUE     | FALSE        | FALSE | FALSE    | FALSE  |
-| survival\_reg         | survival | TRUE  | TRUE     | FALSE        | FALSE | TRUE     | TRUE   |
-| survival\_reg         | flexsurv | TRUE  | TRUE     | FALSE        | FALSE | TRUE     | TRUE   |
+| model                 | engine   | time | survival | linear\_pred | raw | quantile | hazard |
+|:----------------------|:---------|:-----|:---------|:-------------|:----|:---------|:-------|
+| bag\_tree             | rpart    | ✓    | ✓        | x            | x   | x        | x      |
+| boost\_tree           | mboost   | x    | ✓        | ✓            | x   | x        | x      |
+| decision\_tree        | rpart    | ✓    | ✓        | x            | x   | x        | x      |
+| decision\_tree        | party    | ✓    | ✓        | x            | x   | x        | x      |
+| proportional\_hazards | survival | ✓    | ✓        | ✓            | x   | x        | x      |
+| proportional\_hazards | glmnet   | x    | ✓        | ✓            | ✓   | x        | x      |
+| rand\_forest          | party    | ✓    | ✓        | x            | x   | x        | x      |
+| survival\_reg         | survival | ✓    | ✓        | x            | x   | ✓        | ✓      |
+| survival\_reg         | flexsurv | ✓    | ✓        | x            | x   | ✓        | ✓      |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ version with
 devtools::install_github("tidymodels/censored")
 ```
 
-# Available models, engines, and prediction types
+## Available models, engines, and prediction types
 
 censored provides engines for the models in the following table.
 
@@ -45,3 +45,25 @@ with `type = "quantile"`, and the hazard with `type = "hazard"`.
 | rand\_forest          | party    | ✓    | ✓        | x            | x   | x        | x      |
 | survival\_reg         | survival | ✓    | ✓        | x            | x   | ✓        | ✓      |
 | survival\_reg         | flexsurv | ✓    | ✓        | x            | x   | ✓        | ✓      |
+
+## Contributing
+
+This project is released with a [Contributor Code of
+Conduct](https://contributor-covenant.org/version/2/0/CODE_OF_CONDUCT.html).
+By contributing to this project, you agree to abide by its terms.
+
+-   For questions and discussions about tidymodels packages, modeling,
+    and machine learning, please [post on RStudio
+    Community](https://community.rstudio.com/new-topic?category_id=15&tags=tidymodels,question).
+
+-   If you think you have encountered a bug, please [submit an
+    issue](https://github.com/tidymodels/censored/issues).
+
+-   Either way, learn how to create and share a
+    [reprex](https://reprex.tidyverse.org/articles/articles/learn-reprex.html)
+    (a minimal, reproducible example), to clearly communicate about your
+    code.
+
+-   Check out further details on [contributing guidelines for tidymodels
+    packages](https://www.tidymodels.org/contribute/) and [how to get
+    help](https://www.tidymodels.org/help/).

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ devtools::install_github("tidymodels/censored")
 
 ## Available models, engines, and prediction types
 
-censored provides engines for the models in the following table.
+censored provides engines for the models in the following table. For
+examples, please see [Fitting and Predicting with
+censored](https://censored.tidymodels.org/articles/articles/examples.html).
 
 The time to event can be predicted with `type = "time"`, the survival
 probability with `type = "survival"`, the linear predictor with


### PR DESCRIPTION
This PR updates the README to something rather short and hopefully succinct. The table with available models/engines/prediction types is a good overview. The examples have moved to a dedicated article in #103.