### PR TITLE
Fix prediction of single observation

### DIFF
--- a/R/proportional_hazards_data.R
+++ b/R/proportional_hazards_data.R
@@ -48,8 +48,14 @@ make_proportional_hazards_survival <- function() {
       pre = cph_survival_pre,
       post = function(x, object) {
         tabs <- summary(x)$table
-        colnames(tabs) <- gsub("[[:punct:]]", "", colnames(tabs))
-        unname(tabs[, "rmean"])
+        if (is.matrix(tabs)) {
+          colnames(tabs) <- gsub("[[:punct:]]", "", colnames(tabs))
+          res <- unname(tabs[, "rmean"])
+        } else {
+          names(tabs) <- gsub("[[:punct:]]", "", names(tabs))
+          res <- unname(tabs["rmean"])
+        }
+        res
       },
       func = c(fun = "survfit"),
       args =

--- a/tests/testthat/test-proportional_hazards-survival.R
+++ b/tests/testthat/test-proportional_hazards-survival.R
@@ -38,6 +38,9 @@ test_that("time predictions", {
   expect_equivalent(f_pred$.pred_time, unname(exp_f_pred))
   expect_equal(nrow(f_pred), nrow(lung))
 
+  # single observation
+  expect_error(f_pred_1 <- predict(f_fit, lung[1,], type = "time"), NA)
+
   # stratified model but no strata info
   cox_model <- proportional_hazards() %>% set_engine("survival")
   cox_fit_strata <- cox_model %>%


### PR DESCRIPTION
Closes #110 

``` r
library(survival)
library(censored)
#> Loading required package: parsnip
f_fit <- proportional_hazards() %>%
  set_engine("survival") %>% 
  fit(Surv(tstart, tstop, status) ~ treat + inherit + age,
      data = cgd)

predict(f_fit, cgd[1,], type = "time")
#> # A tibble: 1 × 1
#>   .pred_time
#>        <dbl>
#> 1       332.
```

<sup>Created on 2021-11-10 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>