### PR TITLE
Fix predictions of survival prob via party for time points before the first event

### DIFF
--- a/R/party.R
+++ b/R/party.R
@@ -81,7 +81,7 @@ cond_inference_surv_ctree <-
 # some wrappers for ctree predictions
 
 approx_surv_fit <- function(x, .time = 0) {
-  dat <- stack_survfit(x, n = 1)
+  dat <- dplyr::bind_rows(prob_template, stack_survfit(x, n = 1))
   interpolate_km_values_ungrouped(dat, .time)
 }
 


### PR DESCRIPTION
Closes #112

``` r
library(survival)
library(censored)
#> Loading required package: parsnip
# first observation
min(lung$time)
#> [1] 5
# --> prediction of survial probability for time = 4 should be 1

dt_fit <- 
  decision_tree() %>%
  set_engine("party") %>% 
  set_mode("censored regression") %>% 
  fit(Surv(time, status) ~ ., data = lung[-1,])
predict(dt_fit, lung[1, ], type = "survival", time = 4) %>% 
  tidyr::unnest(col = .pred)
#> # A tibble: 1 × 4
#>   .time .pred_survival .pred_survival_lower .pred_survival_upper
#>   <dbl>          <dbl>                <dbl>                <dbl>
#> 1     4              1                   NA                   NA
rf_fit <- 
  rand_forest() %>%
  set_engine("party") %>% 
  set_mode("censored regression") %>% 
  fit(Surv(time, status) ~ ., data = lung[-1,])
predict(rf_fit, lung[1, ], type = "survival", time = 4) %>% 
  tidyr::unnest(col = .pred)
#> # A tibble: 1 × 4
#>   .time .pred_survival .pred_survival_lower .pred_survival_upper
#>   <dbl>          <dbl>                <dbl>                <dbl>
#> 1     4              1                   NA                   NA
```

<sup>Created on 2021-11-10 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>