### PR TITLE
require minumum version for glmnet

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     withr
 Suggests: 
     covr,
-    glmnet,
+    glmnet (>= 4.1),
     party,
     riskRegression,
     rmarkdown,


### PR DESCRIPTION
we need at least v4.1 for the stratification of the Cox model