### PR TITLE
move survival to Depends

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,8 @@ URL: https://github.com/tidymodels/censored
 BugReports: https://github.com/tidymodels/censored/issues
 Depends:
     parsnip (>= 0.1.7.9001),
-    R (>= 2.10)
+    R (>= 2.10),
+    survival
 Imports: 
     dials,
     dplyr (>= 0.8.0.1),
@@ -28,7 +29,6 @@ Imports:
     purrr,
     rlang,
     stats,
-    survival,
     tibble (>= 3.1.3),
     tidyr (>= 1.0.0),
     withr


### PR DESCRIPTION
We (currently) support (only) the formula interface, thus pretty much always need `Surv()` to make the response so I find myself always attaching `survival` for all examples etc. Putting it in Depends instead of Suggest would mean it's attached when `censored` is attached.