### PR TITLE
Interval estimates for survival probabilty

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Suggests:
     rpart,
     testthat
 Remotes: 
-    tidymodels/parsnip
+    tidymodels/parsnip@predict-survival-level
 Config/Needs/website:
     tidymodels,
     tidymodels/parsnip@predict-survival-level,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,10 +41,10 @@ Suggests:
     rpart,
     testthat
 Remotes: 
-    tidymodels/parsnip@predict-survival-level
+    tidymodels/parsnip
 Config/Needs/website:
     tidymodels,
-    tidymodels/parsnip@predict-survival-level,
+    tidymodels/parsnip,
     tidyverse/tidytemplate
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,7 @@ Remotes:
     tidymodels/parsnip
 Config/Needs/website:
     tidymodels,
-    tidymodels/parsnip,
+    tidymodels/parsnip@predict-survival-level,
     tidyverse/tidytemplate
 Encoding: UTF-8
 LazyData: true

--- a/R/censored-package.R
+++ b/R/censored-package.R
@@ -53,5 +53,5 @@ NULL
 utils::globalVariables(
   c("time", ".time", "object", "new_data", ".label", ".pred", ".cuts",
     ".id", ".tmp", "engine", "predictor_indicators", ".strata", "group",
-    ".pred_quantile", ".quantile", "level")
+    ".pred_quantile", ".quantile", "level", "interval")
 )

--- a/R/censored-package.R
+++ b/R/censored-package.R
@@ -50,5 +50,6 @@ NULL
 
 utils::globalVariables(
   c("time", ".time", "object", "new_data", ".label", ".pred", ".cuts",
-    ".id", ".tmp", "engine", "predictor_indicators", ".strata", "group")
+    ".id", ".tmp", "engine", "predictor_indicators", ".strata", "group",
+    "level")
 )

--- a/R/proportional_hazards_data.R
+++ b/R/proportional_hazards_data.R
@@ -81,7 +81,8 @@ make_proportional_hazards_survival <- function() {
           x = quote(object$fit),
           new_data = quote(new_data),
           times = rlang::expr(time),
-          output = c("surv", "conf"),
+          output = "surv",
+          interval = expr(interval),
           conf.int = expr(level)
         )
     )

--- a/R/proportional_hazards_data.R
+++ b/R/proportional_hazards_data.R
@@ -80,7 +80,8 @@ make_proportional_hazards_survival <- function() {
         list(
           x = quote(object$fit),
           new_data = quote(new_data),
-          times = rlang::expr(time)
+          times = rlang::expr(time),
+          output = c("surv", "conf")
         )
     )
   )

--- a/R/proportional_hazards_data.R
+++ b/R/proportional_hazards_data.R
@@ -81,7 +81,8 @@ make_proportional_hazards_survival <- function() {
           x = quote(object$fit),
           new_data = quote(new_data),
           times = rlang::expr(time),
-          output = c("surv", "conf")
+          output = c("surv", "conf"),
+          conf.int = expr(level)
         )
     )
   )

--- a/man/details_proportional_hazards_glmnet.Rd
+++ b/man/details_proportional_hazards_glmnet.Rd
@@ -46,9 +46,8 @@ see \link[parsnip:glmnet-details]{parsnip::glmnet-details}.
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via
-\code{\link[=fit.model_spec]{fit.model_spec()}}, parsnip will
-convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
+parsnip will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/party_internal.Rd
+++ b/man/party_internal.Rd
@@ -2,19 +2,22 @@
 % Please edit documentation in R/party.R
 \name{survival_prob_ctree}
 \alias{survival_prob_ctree}
+\alias{party_internal}
 \alias{survival_prob_cforest}
 \title{Internal helper functions for party objects}
 \usage{
-survival_prob_ctree(object, new_data, time)
+survival_prob_ctree(object, new_data, time, output = "surv")
 
-survival_prob_cforest(object, new_data, time)
+survival_prob_cforest(object, new_data, time, output = "surv")
 }
 \arguments{
 \item{object}{A model object}
 
 \item{new_data}{A data frame to be predicted.}
 
-\item{.time}{A vector of times to predict the survival probability.}
+\item{time}{A vector of times to predict the survival probability.}
+
+\item{output}{Type of output.}
 }
 \value{
 A tibble with a list column of nested tibbles.

--- a/man/survival_prob_cph.Rd
+++ b/man/survival_prob_cph.Rd
@@ -4,7 +4,15 @@
 \alias{survival_prob_cph}
 \title{A wrapper for survival probabilities with cph models}
 \usage{
-survival_prob_cph(x, new_data, times, output = "surv", conf.int = 0.95, ...)
+survival_prob_cph(
+  x,
+  new_data,
+  times,
+  output = "surv",
+  interval = "none",
+  conf.int = 0.95,
+  ...
+)
 }
 \arguments{
 \item{x}{A model from \code{coxph()}.}
@@ -13,9 +21,12 @@ survival_prob_cph(x, new_data, times, output = "surv", conf.int = 0.95, ...)
 
 \item{times}{A vector of integers for prediction times.}
 
-\item{output}{One of "surv", "conf", or "haz".}
+\item{output}{One of \code{"surv"}, \code{"conf"}, or \code{"haz"}.}
 
-\item{conf.int}{The confidence level}
+\item{interval}{Add confidence interval for survival probability? Options
+are \code{"none"} or \code{"confidence"}.}
+
+\item{conf.int}{The confidence level.}
 
 \item{...}{Options to pass to \code{\link[survival:survfit]{survival::survfit()}}}
 }

--- a/tests/testthat/test-decision_tree-party.R
+++ b/tests/testthat/test-decision_tree-party.R
@@ -67,7 +67,7 @@ test_that("survival predictions", {
     101
   )
   cf_names <-
-    c(".time", ".pred_survival", ".pred_survival_lower", ".pred_survival_upper")
+    c(".time", ".pred_survival", ".pred_lower", ".pred_upper")
   expect_true(
     all(purrr::map_lgl(f_pred$.pred,
                        ~ identical(names(.x), cf_names)))

--- a/tests/testthat/test-decision_tree-party.R
+++ b/tests/testthat/test-decision_tree-party.R
@@ -67,7 +67,7 @@ test_that("survival predictions", {
     101
   )
   cf_names <-
-    c(".time", ".pred_survival", ".pred_lower", ".pred_upper")
+    c(".time", ".pred_survival")
   expect_true(
     all(purrr::map_lgl(f_pred$.pred,
                        ~ identical(names(.x), cf_names)))

--- a/tests/testthat/test-proportional_hazards-survival.R
+++ b/tests/testthat/test-proportional_hazards-survival.R
@@ -68,11 +68,15 @@ test_that("survival predictions - non-stratified", {
   expect_equal(nrow(f_pred), nrow(lung))
   expect_true(
     all(purrr::map_lgl(f_pred$.pred,
-                       ~ all(dim(.x) == c(2, 2))))
+                       ~ all(dim(.x) == c(2, 4))))
   )
   expect_true(
-    all(purrr::map_lgl(f_pred$.pred,
-                       ~ all(names(.x) == c(".time", ".pred_survival"))))
+    all(
+      purrr::map_lgl(
+        f_pred$.pred,
+        ~ all(names(.x) == c(".time", ".pred_survival",
+                             ".pred_survival_lower",
+                             ".pred_survival_upper"))))
   )
   expect_equal(
     tidyr::unnest(f_pred, cols = c(.pred))$.pred_survival,
@@ -105,11 +109,14 @@ test_that("survival predictions - stratified", {
   expect_equal(nrow(f_pred), nrow(new_data_3))
   expect_true(
     all(purrr::map_lgl(f_pred$.pred,
-                       ~ all(dim(.x) == c(2, 2))))
+                       ~ all(dim(.x) == c(2, 4))))
   )
   expect_true(
-    all(purrr::map_lgl(f_pred$.pred,
-                       ~ all(names(.x) == c(".time", ".pred_survival"))))
+    all(
+      purrr::map_lgl(
+        f_pred$.pred,
+        ~ all(names(.x) == c(".time", ".pred_survival", ".pred_survival_lower",
+                             ".pred_survival_upper"))))
   )
   expect_equal(
     tidyr::unnest(f_pred, cols = c(.pred))$.pred_survival,

--- a/tests/testthat/test-proportional_hazards-survival.R
+++ b/tests/testthat/test-proportional_hazards-survival.R
@@ -68,15 +68,13 @@ test_that("survival predictions - non-stratified", {
   expect_equal(nrow(f_pred), nrow(lung))
   expect_true(
     all(purrr::map_lgl(f_pred$.pred,
-                       ~ all(dim(.x) == c(2, 4))))
+                       ~ all(dim(.x) == c(2, 2))))
   )
   expect_true(
     all(
       purrr::map_lgl(
         f_pred$.pred,
-        ~ all(names(.x) == c(".time", ".pred_survival",
-                             ".pred_survival_lower",
-                             ".pred_survival_upper"))))
+        ~ all(names(.x) == c(".time", ".pred_survival"))))
   )
   expect_equal(
     tidyr::unnest(f_pred, cols = c(.pred))$.pred_survival,
@@ -109,14 +107,13 @@ test_that("survival predictions - stratified", {
   expect_equal(nrow(f_pred), nrow(new_data_3))
   expect_true(
     all(purrr::map_lgl(f_pred$.pred,
-                       ~ all(dim(.x) == c(2, 4))))
+                       ~ all(dim(.x) == c(2, 2))))
   )
   expect_true(
     all(
       purrr::map_lgl(
         f_pred$.pred,
-        ~ all(names(.x) == c(".time", ".pred_survival", ".pred_survival_lower",
-                             ".pred_survival_upper"))))
+        ~ all(names(.x) == c(".time", ".pred_survival"))))
   )
   expect_equal(
     tidyr::unnest(f_pred, cols = c(.pred))$.pred_survival,
@@ -200,3 +197,53 @@ test_that("predictions with strata and dot in formula", {
   )
 })
 
+test_that("confidence intervals", {
+  cox_spec <- proportional_hazards() %>%
+    set_mode("censored regression") %>%
+    set_engine("survival")
+
+  # survival probabilities unstratified
+  f_fit <- fit(cox_spec, Surv(time, status) ~ age + sex, data = lung)
+  f_pred <- predict(f_fit, lung, type = "survival", time = c(306, 455),
+                    interval = "confidence")
+
+  expect_s3_class(f_pred, "tbl_df")
+  expect_equal(names(f_pred), ".pred")
+  expect_equal(nrow(f_pred), nrow(lung))
+  expect_true(
+    all(purrr::map_lgl(f_pred$.pred,
+                       ~ all(dim(.x) == c(2, 4))))
+  )
+  expect_true(
+    all(
+      purrr::map_lgl(
+        f_pred$.pred,
+        ~ all(names(.x) == c(".time", ".pred_survival",
+                             ".pred_lower",
+                             ".pred_upper"))))
+  )
+
+  # survival probabilities stratified
+  set.seed(14)
+  f_fit <- fit(cox_spec,
+               Surv(stop, event) ~ rx + size + number + strata(enum),
+               data = bladder)
+  new_data_3 <- bladder[1:3, ]
+  f_pred <- predict(f_fit, new_data = new_data_3,  type = "survival",
+                   time = c(10, 20), interval = "confidence")
+
+  expect_s3_class(f_pred, "tbl_df")
+  expect_equal(names(f_pred), ".pred")
+  expect_equal(nrow(f_pred), nrow(new_data_3))
+  expect_true(
+    all(purrr::map_lgl(f_pred$.pred,
+                       ~ all(dim(.x) == c(2, 4))))
+  )
+  expect_true(
+    all(
+      purrr::map_lgl(
+        f_pred$.pred,
+        ~ all(names(.x) == c(".time", ".pred_survival", ".pred_lower",
+                             ".pred_upper"))))
+  )
+})

--- a/tests/testthat/test-rand_forest-party.R
+++ b/tests/testthat/test-rand_forest-party.R
@@ -91,7 +91,7 @@ test_that("survival predictions", {
     101
   )
   cf_names <-
-    c(".time", ".pred_survival", ".pred_lower", ".pred_upper")
+    c(".time", ".pred_survival")
   expect_true(
     all(purrr::map_lgl(f_pred$.pred,
                        ~ identical(names(.x), cf_names)))

--- a/tests/testthat/test-rand_forest-party.R
+++ b/tests/testthat/test-rand_forest-party.R
@@ -91,7 +91,7 @@ test_that("survival predictions", {
     101
   )
   cf_names <-
-    c(".time", ".pred_survival", ".pred_survival_lower", ".pred_survival_upper")
+    c(".time", ".pred_survival", ".pred_lower", ".pred_upper")
   expect_true(
     all(purrr::map_lgl(f_pred$.pred,
                        ~ identical(names(.x), cf_names)))


### PR DESCRIPTION
This PR 

* adds interval estimates for survival probability for Cox models via the `survival` engine. Closes #122
* removes the interval estimates for decision trees and random forests with the `party` engine. We are currently not sure that they account for the uncertainty coming from the tree/forest so we are leaving them out for now.

This needs https://github.com/tidymodels/parsnip/pull/615 to be merged first.

``` r
library(censored)
#> Loading required package: parsnip
#> Loading required package: survival
library(flexsurv)
set.seed(403)

cox_fit <- proportional_hazards() %>%
  set_engine("survival") %>%
  fit(Surv(time, status) ~ age + sex, data = lung)

predict(cox_fit, lung, type = "survival", time = c(306, 455), interval = "confidence") %>%
  dplyr::slice(1) %>%
  tidyr::unnest(cols = .pred)
#> # A tibble: 2 × 4
#>   .time .pred_survival .pred_lower .pred_upper
#>   <dbl>          <dbl>       <dbl>       <dbl>
#> 1   306          0.369       0.277       0.494
#> 2   455          0.189       0.117       0.304

predict(cox_fit, lung, type = "survival", time = c(306, 455), interval = "confidence", level = 0.5) %>%
  dplyr::slice(1) %>%
  tidyr::unnest(cols = .pred)
#> # A tibble: 2 × 4
#>   .time .pred_survival .pred_lower .pred_upper
#>   <dbl>          <dbl>       <dbl>       <dbl>
#> 1   306          0.369       0.334       0.408
#> 2   455          0.189       0.160       0.222
```

<sup>Created on 2021-12-03 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>