### PR TITLE
standarize column names for quantile predictions

### DIFF
--- a/R/censored-package.R
+++ b/R/censored-package.R
@@ -52,5 +52,6 @@ NULL
 
 utils::globalVariables(
   c("time", ".time", "object", "new_data", ".label", ".pred", ".cuts",
-    ".id", ".tmp", "engine", "predictor_indicators", ".strata", "group")
+    ".id", ".tmp", "engine", "predictor_indicators", ".strata", "group",
+    ".pred_quantile", ".quantile")
 )

--- a/R/survival_reg.R
+++ b/R/survival_reg.R
@@ -7,21 +7,19 @@ survreg_quant <- function(results, object) {
   n <- nrow(results)
   p <- ncol(results)
   colnames(results) <- names0(p)
-  results <-
-    results %>%
+
+  res <- results %>%
     tibble::as_tibble(results) %>%
     dplyr::mutate(.row = 1:n) %>%
-    tidyr::gather(.label, .pred, -.row) %>%
+    tidyr::pivot_longer(-.row, names_to = ".label",
+                        values_to = ".pred_quantile") %>%
     dplyr::arrange(.row, .label) %>%
     dplyr::mutate(.quantile = rep(pctl, n)) %>%
-    dplyr::select(-.label)
-  .row <- results[[".row"]]
-  results <-
-    results %>%
+    dplyr::select(.row, .quantile, .pred_quantile) %>%
+    tidyr::nest(.pred = c(-.row)) %>%
     dplyr::select(-.row)
-  results <- split(results, .row)
-  names(results) <- NULL
-  tibble::tibble(.pred = results)
+
+  res
 }
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test_survival_reg_survival.R
+++ b/tests/testthat/test_survival_reg_survival.R
@@ -72,7 +72,7 @@ test_that("survival time prediction", {
   exp_quant <- predict(res$fit, head(lung), p = (2:4) / 5, type = "quantile")
   exp_quant <-
     apply(exp_quant, 1, function(x)
-      tibble(.pred = x, .quantile = (2:4) / 5))
+      tibble(.quantile = (2:4) / 5, .pred_quantile = x))
   exp_quant <- tibble(.pred = exp_quant)
   obs_quant <- predict(res, head(lung), type = "quantile", quantile = (2:4) / 5)
 


### PR DESCRIPTION
Closes #123

``` r
library(censored)
#> Loading required package: parsnip
#> Loading required package: survival

sr_fit_survival <- fit <- survival_reg() %>%
  fit(Surv(time, status) ~ ., data = lung)

# columns of inner tibble should be `.quantile` and `.pred_quantile`
predict(sr_fit_survival, lung[1:3,], type = "quantile", quantile = c(0.5, 0.8)) %>% 
  tidyr::unnest(cols = .pred)
#> # A tibble: 6 × 2
#>   .quantile .pred_quantile
#>       <dbl>          <dbl>
#> 1       0.5            NA 
#> 2       0.8            NA 
#> 3       0.5           423.
#> 4       0.8           754.
#> 5       0.5            NA 
#> 6       0.8            NA
```

<sup>Created on 2021-12-01 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
