### PR TITLE
set dependencies only for censored regression mode

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,10 +41,10 @@ Suggests:
     rpart,
     testthat
 Remotes: 
-    tidymodels/parsnip@mode-specific-dependencies
+    tidymodels/parsnip
 Config/Needs/website:
     tidymodels,
-    tidymodels/parsnip@mode-specific-dependencies,
+    tidymodels/parsnip,
     tidyverse/tidytemplate
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ License: MIT + file LICENSE
 URL: https://github.com/tidymodels/censored
 BugReports: https://github.com/tidymodels/censored/issues
 Depends:
-    parsnip (>= 0.1.7.9002),
+    parsnip (>= 0.1.7.9003),
     R (>= 2.10),
     survival
 Imports: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ License: MIT + file LICENSE
 URL: https://github.com/tidymodels/censored
 BugReports: https://github.com/tidymodels/censored/issues
 Depends:
-    parsnip (>= 0.1.7.9003),
+    parsnip (>= 0.1.7.9004),
     R (>= 2.10),
     survival
 Imports: 
@@ -41,10 +41,10 @@ Suggests:
     rpart,
     testthat
 Remotes: 
-    tidymodels/parsnip
+    tidymodels/parsnip@mode-specific-dependencies
 Config/Needs/website:
     tidymodels,
-    tidymodels/parsnip,
+    tidymodels/parsnip@mode-specific-dependencies,
     tidyverse/tidytemplate
 Encoding: UTF-8
 LazyData: true

--- a/R/bag_tree_data.R
+++ b/R/bag_tree_data.R
@@ -11,8 +11,14 @@
 
 make_bag_tree_rpart <- function() {
   parsnip::set_model_engine("bag_tree", mode = "censored regression", eng = "rpart")
-  parsnip::set_dependency("bag_tree", eng = "rpart", pkg =  "ipred")
-  parsnip::set_dependency("bag_tree", eng = "rpart", pkg = "censored")
+  parsnip::set_dependency("bag_tree",
+                          eng = "rpart",
+                          pkg =  "ipred",
+                          mode = "censored regression")
+  parsnip::set_dependency("bag_tree",
+                          eng = "rpart",
+                          pkg = "censored",
+                          mode = "censored regression")
 
   parsnip::set_fit(
     model = "bag_tree",

--- a/R/boost_tree_data.R
+++ b/R/boost_tree_data.R
@@ -11,8 +11,14 @@
 
 make_boost_tree_mboost <- function() {
   parsnip::set_model_engine("boost_tree", mode = "censored regression", eng = "mboost")
-  parsnip::set_dependency("boost_tree", eng = "mboost", pkg = "mboost")
-  parsnip::set_dependency("boost_tree", eng = "mboost", pkg = "censored")
+  parsnip::set_dependency("boost_tree",
+                          eng = "mboost",
+                          pkg = "mboost",
+                          mode = "censored regression")
+  parsnip::set_dependency("boost_tree",
+                          eng = "mboost",
+                          pkg = "censored",
+                          mode = "censored regression")
 
   parsnip::set_model_arg(
     model = "boost_tree",

--- a/R/decision_tree_data.R
+++ b/R/decision_tree_data.R
@@ -11,8 +11,14 @@
 
 make_decision_tree_rpart <- function() {
   parsnip::set_model_engine("decision_tree", mode = "censored regression", eng = "rpart")
-  parsnip::set_dependency("decision_tree", eng = "rpart", pkg = "pec")
-  parsnip::set_dependency("decision_tree", eng = "rpart", pkg = "censored")
+  parsnip::set_dependency("decision_tree",
+                          eng = "rpart",
+                          pkg = "pec",
+                          mode = "censored regression")
+  parsnip::set_dependency("decision_tree",
+                          eng = "rpart",
+                          pkg = "censored",
+                          mode = "censored regression")
 
   parsnip::set_fit(
     model = "decision_tree",

--- a/R/proportional_hazards_data.R
+++ b/R/proportional_hazards_data.R
@@ -12,8 +12,8 @@
 make_proportional_hazards_survival <- function() {
 
   parsnip::set_model_engine("proportional_hazards", mode = "censored regression", eng = "survival")
-  parsnip::set_dependency("proportional_hazards", eng = "survival", pkg = "survival")
-  parsnip::set_dependency("proportional_hazards", eng = "survival", pkg = "censored")
+  parsnip::set_dependency("proportional_hazards", eng = "survival", pkg = "survival", mode = "censored regression")
+  parsnip::set_dependency("proportional_hazards", eng = "survival", pkg = "censored", mode = "censored regression")
 
   parsnip::set_fit(
     model = "proportional_hazards",
@@ -102,8 +102,14 @@ make_proportional_hazards_survival <- function() {
 make_proportional_hazards_glmnet <- function() {
 
   parsnip::set_model_engine("proportional_hazards", mode = "censored regression", eng = "glmnet")
-  parsnip::set_dependency("proportional_hazards", eng = "glmnet", pkg =  "glmnet")
-  parsnip::set_dependency("proportional_hazards", eng = "glmnet", pkg = "censored")
+  parsnip::set_dependency("proportional_hazards",
+                          eng = "glmnet",
+                          pkg =  "glmnet",
+                          mode = "censored regression")
+  parsnip::set_dependency("proportional_hazards",
+                          eng = "glmnet",
+                          pkg = "censored",
+                          mode = "censored regression")
 
   parsnip::set_fit(
     model = "proportional_hazards",

--- a/R/rand_forest_data.R
+++ b/R/rand_forest_data.R
@@ -12,9 +12,18 @@
 make_rand_forest_party <- function() {
 
   parsnip::set_model_engine("rand_forest", mode = "censored regression", eng = "party")
-  parsnip::set_dependency("rand_forest", eng = "party", pkg = "party")
-  parsnip::set_dependency("rand_forest", eng = "party", pkg = "modeltools")
-  parsnip::set_dependency("rand_forest", eng = "party", pkg = "censored")
+  parsnip::set_dependency("rand_forest",
+                          eng = "party",
+                          pkg = "party",
+                          mode = "censored regression")
+  parsnip::set_dependency("rand_forest",
+                          eng = "party",
+                          pkg = "modeltools",
+                          mode = "censored regression")
+  parsnip::set_dependency("rand_forest",
+                          eng = "party",
+                          pkg = "censored",
+                          mode = "censored regression")
 
   parsnip::set_fit(
     model = "rand_forest",

--- a/R/survival_reg_data.R
+++ b/R/survival_reg_data.R
@@ -12,8 +12,14 @@
 make_survival_reg_survival <- function() {
 
   parsnip::set_model_engine("survival_reg", mode = "censored regression", eng = "survival")
-  parsnip::set_dependency("survival_reg", eng = "survival", pkg = "survival")
-  parsnip::set_dependency("survival_reg", eng = "survival", pkg = "censored")
+  parsnip::set_dependency("survival_reg",
+                          eng = "survival",
+                          pkg = "survival",
+                          mode = "censored regression")
+  parsnip::set_dependency("survival_reg",
+                          eng = "survival",
+                          pkg = "censored",
+                          mode = "censored regression")
 
   parsnip::set_model_arg(
     model = "survival_reg",
@@ -142,9 +148,18 @@ make_survival_reg_survival <- function() {
 make_survival_reg_flexsurv <- function() {
 
   parsnip::set_model_engine("survival_reg", mode = "censored regression", eng = "flexsurv")
-  parsnip::set_dependency("survival_reg", eng = "flexsurv", pkg = "flexsurv")
-  parsnip::set_dependency("survival_reg", eng = "flexsurv", pkg = "survival")
-  parsnip::set_dependency("survival_reg", eng = "flexsurv", pkg = "censored")
+  parsnip::set_dependency("survival_reg",
+                          eng = "flexsurv",
+                          pkg = "flexsurv",
+                          mode = "censored regression")
+  parsnip::set_dependency("survival_reg",
+                          eng = "flexsurv",
+                          pkg = "survival",
+                          mode = "censored regression")
+  parsnip::set_dependency("survival_reg",
+                          eng = "flexsurv",
+                          pkg = "censored",
+                          mode = "censored regression")
 
   parsnip::set_model_arg(
     model = "survival_reg",


### PR DESCRIPTION
Depending on tidymodels/parsnip#629, set package dependnecies here to be specific to the censored regression mode. This would stop package dependencies from being aggregated across all model modes: 

```
> library(censored)
Loading required package: parsnip
Loading required package: survival
> get_from_env("decision_tree_pkgs")
# A tibble: 7 × 3
  engine pkg       mode               
  <chr>  <list>    <chr>              
1 C5.0   <chr [1]> classification     
2 party  <chr [2]> censored regression
3 rpart  <chr [2]> censored regression
4 rpart  <chr [1]> classification     
5 rpart  <chr [1]> regression         
6 spark  <chr [1]> classification     
7 spark  <chr [1]> regression    
```