### PR TITLE
Predict on data with `NA` for `proportional_hazards()` with `survival` engine

### DIFF
--- a/R/aaa_survival_prop.R
+++ b/R/aaa_survival_prop.R
@@ -250,6 +250,19 @@ predict_survival_na <- function(time, interval = "none") {
 #' @export
 survival_time_coxph <- function(object, new_data) {
 
+  missings_in_new_data <- get_missings(object, new_data)
+  if (!is.null(missings_in_new_data)) {
+    n_total <- nrow(new_data)
+    n_missing <- length(missings_in_new_data)
+    all_missing <- n_missing == n_total
+    if (all_missing) {
+      ret <- rep(NA, n_missing)
+      return(ret)
+    }
+    new_data <- new_data[-missings_in_new_data, ]
+  }
+
+
   y <- survival::survfit(object, new_data, na.action = stats::na.exclude)
 
   # work around https://github.com/therneau/survival/issues/130
@@ -266,6 +279,11 @@ survival_time_coxph <- function(object, new_data) {
   } else {
     names(tabs) <- gsub("[[:punct:]]", "", names(tabs))
     res <- unname(tabs["rmean"])
+  }
+  if (!is.null(missings_in_new_data)) {
+    index_with_na <- rep(NA, n_total)
+    index_with_na[-missings_in_new_data] <- seq_along(res)
+    res <- res[index_with_na]
   }
   res
 }

--- a/tests/testthat/test-proportional_hazards-survival.R
+++ b/tests/testthat/test-proportional_hazards-survival.R
@@ -77,6 +77,70 @@ test_that("time predictions with strata", {
   )
 })
 
+test_that("time predictions with NA", {
+
+  cox_spec <- proportional_hazards() %>% set_engine("survival")
+  expect_error(
+    f_fit <- fit(cox_spec, Surv(time, status) ~ age + strata(ph.ecog),
+                 data = lung),
+    NA
+  )
+
+  # survfit.coxph() is not type-stable,
+  # thus test against single or multiple survival curves
+  # lung$ph.ecog[14] is NA
+  na_x_data_x <- lung[c(13:15, 14),]
+  na_x_data_1 <- lung[c(13, 14, 14),]
+  na_x_data_0 <- lung[c(14, 14),]
+  na_1_data_x <- lung[13:15,]
+  na_1_data_1 <- lung[13:14,]
+  na_1_data_0 <- lung[14,]
+
+  # survival time
+  expect_error(
+    f_pred <- predict(f_fit, na_x_data_x, type = "time"),
+    NA
+  )
+  expect_equal(nrow(f_pred), nrow(na_x_data_x))
+  expect_equal(which(is.na(f_pred$.pred_time)), c(2, 4))
+
+  expect_error(
+    f_pred <- predict(f_fit, na_x_data_1, type = "time"),
+    NA
+  )
+  expect_equal(nrow(f_pred), nrow(na_x_data_1))
+  expect_equal(which(is.na(f_pred$.pred_time)), c(2, 3))
+
+  expect_error(
+    f_pred <- predict(f_fit, na_x_data_0, type = "time"),
+    NA
+  )
+  expect_equal(nrow(f_pred), nrow(na_x_data_0))
+  expect_equal(which(is.na(f_pred$.pred_time)), 1:2)
+
+  expect_error(
+    f_pred <- predict(f_fit, na_1_data_x, type = "time"),
+    NA
+  )
+  expect_equal(nrow(f_pred), nrow(na_1_data_x))
+  expect_equal(which(is.na(f_pred$.pred_time)), 2)
+
+  expect_error(
+    f_pred <- predict(f_fit, na_1_data_1, type = "time"),
+    NA
+  )
+  expect_equal(nrow(f_pred), nrow(na_1_data_1))
+  expect_equal(which(is.na(f_pred$.pred_time)), 2)
+
+  expect_error(
+    f_pred <- predict(f_fit, na_1_data_0, type = "time"),
+    NA
+  )
+  expect_equal(nrow(f_pred), nrow(na_1_data_0))
+  expect_true(is.na(f_pred$.pred_time))
+
+})
+
 
 # prediction: survival probabilities --------------------------------------
 


### PR DESCRIPTION
Closes #40

We use the survival curves from `survival::survfit.coxph()` for predictions of types `survival` and `time`. Observations with `NA` get omitted by `survfit()` so we now pad results accordingly.

``` r
library(censored)
#> Loading required package: parsnip
#> Loading required package: survival

cox_mod <-
  proportional_hazards() %>%
  set_engine("survival") %>%
  fit(Surv(time, status) ~ age + ph.ecog, data = lung)

lung$ph.ecog[14]
#> [1] NA

predict(cox_mod, type = "survival", new_data = lung[13:15,], time = c(100, 200)) %>%
  tidyr::unnest(cols = .pred)
#> # A tibble: 6 × 2
#>   .time .pred_survival
#>   <dbl>          <dbl>
#> 1   100          0.864
#> 2   200          0.668
#> 3   100         NA    
#> 4   200         NA    
#> 5   100          0.879
#> 6   200          0.700

predict(cox_mod, type = "time", new_data = lung[13:15,])
#> # A tibble: 3 × 1
#>   .pred_time
#>        <dbl>
#> 1       358.
#> 2        NA 
#> 3       389.
```

<sup>Created on 2022-02-02 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

