### PR TITLE
reactivate checks on `oldrel-1` and `oldrel-2`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,10 +32,8 @@ jobs:
           # Use older ubuntu to maximise backward compatibility
           - {os: ubuntu-18.04,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-18.04,   r: 'release'}
-          # quantreg v5.87 needs R >= 4.1.0
-          # https://community.rstudio.com/t/github-action-r-cmd-check-failed-to-build-soruce-quantreg-on-ubuntu-oldrel-1/127654/6
-          #- {os: ubuntu-18.04,   r: 'oldrel-1'}
-          #- {os: ubuntu-18.04,   r: 'oldrel-2'}
+          - {os: ubuntu-18.04,   r: 'oldrel-1'}
+          - {os: ubuntu-18.04,   r: 'oldrel-2'}
           # glmnet needs R >= 3.6
           #- {os: ubuntu-18.04,   r: 'oldrel-3'}
           #- {os: ubuntu-18.04,   r: 'oldrel-4'}


### PR DESCRIPTION
quantreg got updated so does not require R >= 4.1.0 anymore