### PR TITLE
bug fixed in survival

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ BugReports: https://github.com/tidymodels/censored/issues
 Depends:
     parsnip (>= 0.1.7.9004),
     R (>= 3.5.0),
-    survival
+    survival (>= 3.3-1)
 Imports: 
     dials,
     dplyr (>= 0.8.0.1),

--- a/R/aaa_survival_prop.R
+++ b/R/aaa_survival_prop.R
@@ -42,10 +42,6 @@ survival_prob_cph <- function(x,
   if (has_strata(x$terms)) {
     new_strata <- compute_strata(x, new_data) %>%
       dplyr::pull(.strata)
-    # work around https://github.com/therneau/survival/issues/130
-    if (nrow(new_data) == 1L){
-      y <- tweak_survfit_for_single_obs(y, new_strata)
-    }
   } else {
     new_strata <- NULL
   }
@@ -203,25 +199,6 @@ cph_survival_pre <- function(new_data, object) {
   new_data
 }
 
-tweak_survfit_for_single_obs <- function(object, stratum) {
-
-  all_strata <- names(object$strata)
-
-  stratum_ind <- which(stratum == all_strata)
-  time_points_in_stratum <-
-    sum(object$strata[seq_len(stratum_ind - 1)]) +
-    seq_len(object$strata[stratum_ind])
-
-  cls <- class(object)
-  ret <- unclass(object) %>%
-    purrr::map_at(c("n", "strata"), ~ .x[stratum_ind]) %>%
-    purrr::map_at(c("time", "n.risk", "n.event", "n.censor", "surv",
-                    "cumhaz", "std.err", "lower", "upper"),
-                  ~ .x[time_points_in_stratum])
-  class(ret) <- cls
-  ret
-}
-
 # see https://github.com/therneau/survival/issues/137
 get_missings_coxph <- function(object, new_data) {
   trms <- stats::terms(object)
@@ -265,13 +242,6 @@ survival_time_coxph <- function(object, new_data) {
 
 
   y <- survival::survfit(object, new_data, na.action = stats::na.exclude)
-
-  # work around https://github.com/therneau/survival/issues/130
-  if (has_strata(object$terms) && nrow(new_data) == 1L) {
-    new_strata <- compute_strata(object, new_data) %>%
-      dplyr::pull(.strata)
-    y <- tweak_survfit_for_single_obs(y, new_strata)
-  }
 
   tabs <- summary(y)$table
   if (is.matrix(tabs)) {
@@ -324,12 +294,6 @@ survival_prob_coxnet <- function(object, new_data, times, output = "surv", penal
     na.action = na.exclude,
     ...
   )
-
-  # work around https://github.com/therneau/survival/issues/130
-  if (has_strata(object$formula, object$training_data) &&
-      nrow(new_data) == 1L) {
-    y <- tweak_survfit_for_single_obs(y, new_strata)
-  }
 
   if (multi) {
     keep_penalty <- TRUE

--- a/tests/testthat/_snaps/proportional_hazards-glmnet.md
+++ b/tests/testthat/_snaps/proportional_hazards-glmnet.md
@@ -94,8 +94,6 @@
     Condition
       Warning in `terms.formula()`:
       'varlist' has changed (from nvar=5) to new 6 after EncodeVars() -- should no longer happen!
-      Warning in `terms.formula()`:
-      'varlist' has changed (from nvar=5) to new 6 after EncodeVars() -- should no longer happen!
     Output
       # A tibble: 227 x 1
          .pred           
@@ -117,8 +115,6 @@
     Code
       f_pred <- predict(f_fit, lung2, type = "survival", time = c(100, 300))
     Condition
-      Warning in `terms.formula()`:
-      'varlist' has changed (from nvar=5) to new 6 after EncodeVars() -- should no longer happen!
       Warning in `terms.formula()`:
       'varlist' has changed (from nvar=5) to new 6 after EncodeVars() -- should no longer happen!
     Code


### PR DESCRIPTION
survival used to return survival curves for _all_ strata if there was only a single observation in `newdata`. that's now fixed in survival so I'm removing the workaround