### PR TITLE
checks for R 3.6

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,7 +34,8 @@ jobs:
           - {os: ubuntu-18.04,   r: 'release'}
           - {os: ubuntu-18.04,   r: 'oldrel-1'}
           - {os: ubuntu-18.04,   r: 'oldrel-2'}
-          - {os: ubuntu-18.04,   r: 'oldrel-3'}
+          # flexsurv's dependency deSolve needs R >= 4.0.0
+          #- {os: ubuntu-18.04,   r: 'oldrel-3'}
           # glmnet needs R >= 3.6
           #- {os: ubuntu-18.04,   r: 'oldrel-4'}
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,8 +34,8 @@ jobs:
           - {os: ubuntu-18.04,   r: 'release'}
           - {os: ubuntu-18.04,   r: 'oldrel-1'}
           - {os: ubuntu-18.04,   r: 'oldrel-2'}
+          - {os: ubuntu-18.04,   r: 'oldrel-3'}
           # glmnet needs R >= 3.6
-          #- {os: ubuntu-18.04,   r: 'oldrel-3'}
           #- {os: ubuntu-18.04,   r: 'oldrel-4'}
 
     env:


### PR DESCRIPTION
with the release of R 4.2, `oldrel-3` is now R 3.6.3 and should be run again