### PR TITLE
improve error message for checking usage of `strata()`

### DIFF
--- a/R/proportional_hazards_data.R
+++ b/R/proportional_hazards_data.R
@@ -323,7 +323,7 @@ get_strata_glmnet <- function(formula, data, na.action = stats::na.omit) {
   strata
 }
 
-remove_strata <- function(formula, data) {
+remove_strata <- function(formula, data, call = rlang::caller_env()) {
   if (!has_strata(formula, data)) {
     return(formula)
   }
@@ -332,7 +332,7 @@ remove_strata <- function(formula, data) {
   formula[[3]] <- rhs %>%
     drop_strata() %>%
     check_intercept_model() %>%
-    check_strata_remaining()
+    check_strata_remaining(call = call)
   formula
 }
 
@@ -365,11 +365,18 @@ check_intercept_model <- function(expr) {
   expr
 }
 
-check_strata_remaining <- function(expr) {
+check_strata_remaining <- function(expr, call = rlang::caller_env()) {
   if (is_call(expr, "strata")) {
-    abort("Stratification needs to be specified via `+ strata()`.")
+    abort(
+      c(
+        "Stratification must be nested under a chain of `+` calls.",
+        i = "# Good: ~ x1 + x2 + strata(s)",
+        i = "# Bad: ~ x1 + (x2 + strata(s))"
+      ),
+      call = call
+    )
   } else if (is_call(expr)) {
-    expr[-1] <- map(as.list(expr[-1]), check_strata_remaining)
+    expr[-1] <- map(as.list(expr[-1]), check_strata_remaining, call = call)
     expr
   } else {
     expr

--- a/tests/testthat/_snaps/proportional_hazards-glmnet.md
+++ b/tests/testthat/_snaps/proportional_hazards-glmnet.md
@@ -17,6 +17,17 @@
       * To try multiple values for total regularization, use the tune package.
       * To predict multiple penalties, use `multi_predict()`
 
+# formula modifications
+
+    Code
+      proportional_hazards(penalty = 0.1) %>% set_engine("glmnet") %>% fit(Surv(time,
+        status) ~ age + (ph.ecog + strata(sex)), data = lung)
+    Condition
+      Error in `censored::glmnet_fit_wrapper()`:
+      ! Stratification must be nested under a chain of `+` calls.
+      i # Good: ~ x1 + x2 + strata(s)
+      i # Bad: ~ x1 + (x2 + strata(s))
+
 # predictions with strata and dot in formula
 
     Code

--- a/tests/testthat/test-proportional_hazards-glmnet.R
+++ b/tests/testthat/test-proportional_hazards-glmnet.R
@@ -742,6 +742,13 @@ test_that("formula modifications", {
   expect_error(
     check_strata_remaining(rlang::expr(x * (y + strata(s)) + z))
   )
+
+  expect_snapshot(error = TRUE, {
+    proportional_hazards(penalty = 0.1) %>%
+      set_engine("glmnet") %>%
+      fit(Surv(time, status) ~ age + (ph.ecog + strata(sex)),
+          data = lung)
+  })
 })
 
 


### PR DESCRIPTION
closes #68 

``` r
censored:::check_strata_remaining(rlang::expr(x * (y + strata(s)) + z))
#> Error:
#> ! Stratification must be nested under a chain of `+` calls.
#> ℹ # Good: ~ x1 + x2 + strata(s)
#> ℹ # Bad: ~ x1 + (x2 + strata(s))
```

<sup>Created on 2022-05-20 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>