### PR TITLE
Dependencies clean-up 🧼 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,6 @@ Suggests:
     ipred,
     partykit,
     pec,
-    riskRegression,
     rmarkdown,
     rpart,
     testthat (>= 3.0.0)

--- a/R/boost_tree.R
+++ b/R/boost_tree.R
@@ -113,7 +113,10 @@ floor_surv_mboost <- function(x, time) {
 #' @export
 survival_time_mboost <- function(object, new_data) {
 
-  y <- mboost::survFit(object, new_data)
+  survFit_call <- rlang::call2("survFit", .ns = "mboost")
+  survFit_call$object <- object
+  survFit_call$newdata <- new_data
+  y <- eval_tidy(survFit_call)
 
   stacked_survfit <- stack_survfit(y, n = nrow(new_data))
 

--- a/tests/testthat/test-bag_tree-rpart.R
+++ b/tests/testthat/test-bag_tree-rpart.R
@@ -1,6 +1,8 @@
 library(testthat)
 
 test_that("model object", {
+  skip_if_not_installed("ipred")
+
   set.seed(1234)
   exp_f_fit <- ipred::bagging(Surv(time, status) ~ age + ph.ecog, data = lung)
 
@@ -20,6 +22,8 @@ test_that("model object", {
 # prediction: time --------------------------------------------------------
 
 test_that("time predictions", {
+  skip_if_not_installed("ipred")
+
   set.seed(1234)
   exp_f_fit <- ipred::bagging(Surv(time, status) ~ age + ph.ecog, data = lung)
   exp_f_pred <- predict(exp_f_fit, lung)
@@ -58,6 +62,8 @@ test_that("time predictions without surrogate splits for NA", {
 # prediction: survival ----------------------------------------------------
 
 test_that("survival predictions", {
+  skip_if_not_installed("ipred")
+
   set.seed(1234)
   exp_f_fit <- ipred::bagging(Surv(time, status) ~ age + ph.ecog, data = lung)
 

--- a/tests/testthat/test-boost_tree-mboost.R
+++ b/tests/testthat/test-boost_tree-mboost.R
@@ -1,6 +1,8 @@
 library(testthat)
 
 test_that("model object", {
+  skip_if_not_installed("mboost")
+
   lung2 <- lung[-14, ]
   exp_f_fit <- mboost::blackboost(Surv(time, status) ~ age + ph.ecog,
                                   data = lung2,
@@ -25,6 +27,8 @@ test_that("model object", {
 
 
 test_that("survival predictions", {
+  skip_if_not_installed("mboost")
+
   pred_time <- c(0, 100, 200, 10000)
 
   lung2 <- lung[-14, ]
@@ -63,6 +67,8 @@ test_that("survival predictions", {
 })
 
 test_that("linear_pred predictions", {
+  skip_if_not_installed("mboost")
+
   lung2 <- lung[-14, ]
   exp_f_fit <- mboost::blackboost(Surv(time, status) ~ age + ph.ecog,
                                   data = lung2,

--- a/tests/testthat/test-decision_tree-rpart.R
+++ b/tests/testthat/test-decision_tree-rpart.R
@@ -1,6 +1,8 @@
 library(testthat)
 
 test_that("model object", {
+  skip_if_not_installed("pec")
+
   set.seed(1234)
   exp_f_fit <- pec::pecRpart(Surv(time, status) ~ age + ph.ecog, data = lung)
 
@@ -18,6 +20,8 @@ test_that("model object", {
 })
 
 test_that("time predictions", {
+  skip_if_not_installed("pec")
+
   set.seed(1234)
   exp_f_fit <- pec::pecRpart(Surv(time, status) ~ age + ph.ecog, data = lung)
 
@@ -37,6 +41,8 @@ test_that("time predictions", {
 })
 
 test_that("survival predictions", {
+  skip_if_not_installed("pec")
+
   set.seed(1234)
   exp_f_fit <- pec::pecRpart(Surv(time, status) ~ age + ph.ecog, data = lung)
 

--- a/tests/testthat/test-proportional_hazards-glmnet.R
+++ b/tests/testthat/test-proportional_hazards-glmnet.R
@@ -538,6 +538,7 @@ test_that("survival prediction with NA in strata", {
 # prediction: time --------------------------------------------------------
 
 test_that("time predictions without strata", {
+  skip_if_not_installed("glmnet")
 
   # remove row with missing value in ph.ecog
   lung2 <- lung[-14, ]
@@ -578,6 +579,7 @@ test_that("time predictions without strata", {
 })
 
 test_that("time predictions with strata", {
+  skip_if_not_installed("glmnet")
 
   # remove row with missing value in ph.ecog
   lung2 <- lung[-14, ]

--- a/tests/testthat/test-proportional_hazards-survival.R
+++ b/tests/testthat/test-proportional_hazards-survival.R
@@ -147,6 +147,8 @@ test_that("time predictions with NA", {
 # prediction: survival probabilities --------------------------------------
 
 test_that("survival predictions without strata", {
+  skip_if_not_installed("pec")
+
   cox_spec <- proportional_hazards() %>% set_engine("survival")
   exp_f_fit <- coxph(Surv(time, status) ~ age + sex, data = lung, x = TRUE)
 

--- a/tests/testthat/test_survival_reg_flexsurv.R
+++ b/tests/testthat/test_survival_reg_flexsurv.R
@@ -24,6 +24,8 @@ test_that("flexsurv execution", {
 })
 
 test_that("flexsurv time prediction", {
+  skip_if_not_installed("flexsurv")
+
   exp_fit <- flexsurv::flexsurvreg(Surv(time, status) ~ age, data = lung,
                                    dist = "lognormal")
   exp_pred <- predict(exp_fit, head(lung), type = "response")
@@ -122,6 +124,8 @@ test_that("hazard prediction", {
 })
 
 test_that("quantile predictions", {
+  skip_if_not_installed("flexsurv")
+
   set.seed(1)
   fit_s <- survival_reg() %>%
     set_engine("flexsurv") %>%
@@ -173,6 +177,8 @@ test_that("quantile predictions", {
 })
 
 test_that("linear predictor", {
+  skip_if_not_installed("flexsurv")
+
   f_fit <- survival_reg() %>%
     set_engine("flexsurv") %>%
     fit(Surv(time, status) ~ age + sex, data = lung)


### PR DESCRIPTION
closes #39

- removes `riskRegression` which is not used
- for suggested packages: moves from functions via `::` to making and evaluating a call via rlang
- guards tests for suggested packages

A question: Could/Should I move `mboost` to Suggests? The only instance (outside of tests) of using it via `::` is in an expression:
https://github.com/tidymodels/censored/blob/24015a6d45fe5c4b8a9f0c083522e09a57bd7685/R/boost_tree_data.R#L76