### PR TITLE
stopgap for flexsurv

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Imports:
 Suggests:
     coin,
     covr,
-    flexsurv (>= 2.2),
+    flexsurv,
     glmnet (>= 4.1),
     ipred,
     partykit,
@@ -42,7 +42,6 @@ Suggests:
     rpart,
     testthat (>= 3.0.0)
 Remotes: 
-    flexsurv=chjackson/flexsurv-dev,
     tidymodels/parsnip
 Config/Needs/website:
     tidymodels,

--- a/R/survival_reg.R
+++ b/R/survival_reg.R
@@ -124,3 +124,20 @@ hazard_survreg <- function(object, new_data, time) {
     )
   tibble::tibble(.pred = unname(res))
 }
+
+
+# helper for flexsurv -----------------------------------------------------
+
+require_flexsurv_version <- function(new_data, object) {
+  if (!rlang::is_installed("flexsurv", version = "2.2")) {
+    rlang::abort(
+      c(
+        "This prediction type needs the development version of the `flexsurv` package.",
+        i = "You can install it with `remotes::install_github('chjackson/flexsurv-dev')`"
+      ),
+      call = rlang::expr(predict())
+    )
+  }
+
+  new_data
+}

--- a/R/survival_reg_data.R
+++ b/R/survival_reg_data.R
@@ -200,7 +200,7 @@ make_survival_reg_flexsurv <- function() {
     mode = "censored regression",
     type = "time",
     value = list(
-      pre = NULL,
+      pre = require_flexsurv_version,
       post = NULL,
       func = c(fun = "predict"),
       args =
@@ -218,7 +218,7 @@ make_survival_reg_flexsurv <- function() {
     mode = "censored regression",
     type = "quantile",
     value = list(
-      pre = NULL,
+      pre = require_flexsurv_version,
       post = NULL,
       func = c(fun = "predict"),
       args =
@@ -239,7 +239,7 @@ make_survival_reg_flexsurv <- function() {
     mode = "censored regression",
     type = "hazard",
     value = list(
-      pre = NULL,
+      pre = require_flexsurv_version,
       post = NULL,
       func = c(fun = "predict"),
       args =
@@ -258,7 +258,7 @@ make_survival_reg_flexsurv <- function() {
     mode = "censored regression",
     type = "survival",
     value = list(
-      pre = NULL,
+      pre = require_flexsurv_version,
       post = NULL,
       func = c(fun = "predict"),
       args =
@@ -279,7 +279,7 @@ make_survival_reg_flexsurv <- function() {
     mode = "censored regression",
     type = "linear_pred",
     value = list(
-      pre = NULL,
+      pre = require_flexsurv_version,
       post = function(results, object) {
         results %>%
           dplyr::mutate(.pred_linear_pred = log(.pred_link)) %>%

--- a/tests/testthat/_snaps/survival_reg_flexsurv.md
+++ b/tests/testthat/_snaps/survival_reg_flexsurv.md
@@ -1,0 +1,45 @@
+# error for flexsurv non-dev version
+
+    Code
+      predict(f_fit, head(lung), type = "time")
+    Condition
+      Error in `predict()`:
+      ! This prediction type needs the development version of the `flexsurv` package.
+      i You can install it with `remotes::install_github('chjackson/flexsurv-dev')`
+
+---
+
+    Code
+      predict(f_fit, head(lung), type = "survival", time = c(0, 500, 1000))
+    Condition
+      Error in `predict()`:
+      ! This prediction type needs the development version of the `flexsurv` package.
+      i You can install it with `remotes::install_github('chjackson/flexsurv-dev')`
+
+---
+
+    Code
+      predict(f_fit, head(lung), type = "hazard", time = c(0, 500, 1000))
+    Condition
+      Error in `predict()`:
+      ! This prediction type needs the development version of the `flexsurv` package.
+      i You can install it with `remotes::install_github('chjackson/flexsurv-dev')`
+
+---
+
+    Code
+      predict(f_fit, head(lung), type = "linear_pred")
+    Condition
+      Error in `predict()`:
+      ! This prediction type needs the development version of the `flexsurv` package.
+      i You can install it with `remotes::install_github('chjackson/flexsurv-dev')`
+
+---
+
+    Code
+      predict(fit_s, new_data = bladder[1:3, ], type = "quantile")
+    Condition
+      Error in `predict()`:
+      ! This prediction type needs the development version of the `flexsurv` package.
+      i You can install it with `remotes::install_github('chjackson/flexsurv-dev')`
+

--- a/tests/testthat/test_survival_reg_flexsurv.R
+++ b/tests/testthat/test_survival_reg_flexsurv.R
@@ -23,7 +23,40 @@ test_that("flexsurv execution", {
   )
 })
 
+test_that("error for flexsurv non-dev version", {
+  skip_if(utils::packageVersion("flexsurv") > "2.1")
+
+  f_fit <- survival_reg(dist = "lognormal") %>%
+    set_engine("flexsurv") %>%
+    fit(Surv(time, status) ~ age, data = lung)
+
+  expect_snapshot(error = TRUE, {
+    predict(f_fit, head(lung), type = "time")
+  })
+  expect_snapshot(error = TRUE, {
+    predict(f_fit, head(lung), type = "survival", time = c(0, 500, 1000))
+  })
+  expect_snapshot(error = TRUE, {
+    predict(f_fit, head(lung), type = "hazard", time = c(0, 500, 1000))
+  })
+  expect_snapshot(error = TRUE, {
+    predict(f_fit, head(lung), type = "linear_pred")
+  })
+
+  fit_s <- survival_reg() %>%
+    set_engine("flexsurv") %>%
+    set_mode("censored regression") %>%
+    fit(Surv(stop, event) ~ rx + size + enum, data = bladder)
+  expect_snapshot(error = TRUE, {
+    predict(fit_s, new_data = bladder[1:3,], type = "quantile")
+  })
+
+})
+
+
 test_that("flexsurv time prediction", {
+  skip_if_not_installed("flexsurv", "2.2")
+
   exp_fit <- flexsurv::flexsurvreg(Surv(time, status) ~ age, data = lung,
                                    dist = "lognormal")
   exp_pred <- predict(exp_fit, head(lung), type = "response")
@@ -38,6 +71,8 @@ test_that("flexsurv time prediction", {
 
 
 test_that("survival probability prediction", {
+  skip_if_not_installed("flexsurv", "2.2")
+
   rms_surv <- readRDS(test_path("data", "rms_surv.rds"))
   f_fit <- survival_reg(dist = "weibull") %>%
     set_engine("flexsurv") %>%
@@ -86,6 +121,8 @@ test_that("survival probability prediction", {
 
 
 test_that("hazard prediction", {
+  skip_if_not_installed("flexsurv", "2.2")
+
   rms_haz <- readRDS(test_path("data", "rms_haz.rds"))
   f_fit <- survival_reg(dist = "weibull") %>%
     set_engine("flexsurv") %>%
@@ -122,6 +159,8 @@ test_that("hazard prediction", {
 })
 
 test_that("quantile predictions", {
+  skip_if_not_installed("flexsurv", "2.2")
+
   set.seed(1)
   fit_s <- survival_reg() %>%
     set_engine("flexsurv") %>%
@@ -173,6 +212,8 @@ test_that("quantile predictions", {
 })
 
 test_that("linear predictor", {
+  skip_if_not_installed("flexsurv", "2.2")
+
   f_fit <- survival_reg() %>%
     set_engine("flexsurv") %>%
     fit(Surv(time, status) ~ age + sex, data = lung)

--- a/vignettes/articles/examples.Rmd
+++ b/vignettes/articles/examples.Rmd
@@ -414,7 +414,7 @@ The following examples use the same data set throughout.
 
   The holdout data can be predicted for survival probability at different time points as well as event time, linear predictor, quantile, and hazard. 
   
-  ```{r}
+  ```{r, eval = FALSE}
   predict(
     sr_fit, 
     lung_test, 


### PR DESCRIPTION
The predictions only work properly with the current dev version (v2.2) so this is a stopgap until the new version is on CRAN.

- the remote for flexsurv is removed from the DESCRIPTION
- the prediction modules have a `pre` function which checks the installed version of flexsurv and suggests to install the dev version if necessary
- the regular tests only run if the dev version is available
- a new test checks that calling `predict()` results in the error with the hint on how to install the dev version
- the article only shows the prediction code but doesn't evaluate it