### PR TITLE
Dependencies clean-up

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,6 @@ Suggests:
     ipred,
     partykit,
     pec,
-    riskRegression,
     rmarkdown,
     rpart,
     testthat (>= 3.0.0)


### PR DESCRIPTION
closes #39

This PR removes `riskRegression` from the DESCRIPTION because it is not being used.