### PR TITLE
conditionally specify `multiple` arg for `multi_predict` join

### DIFF
--- a/R/proportional_hazards.R
+++ b/R/proportional_hazards.R
@@ -178,7 +178,12 @@ multi_predict_coxnet_linear_pred <- function(object, new_data, opts, penalty) {
       names_to = "group",
       values_to = ".pred_linear_pred"
     )
-  pred <- dplyr::inner_join(param_key, pred, by = "group") %>%
+  if (utils::packageVersion("dplyr") >= "1.0.99.9000") {
+    pred <- dplyr::inner_join(param_key, pred, by = "group", multiple = "all")
+  } else {
+    pred <- dplyr::inner_join(param_key, pred, by = "group")
+  }
+  pred <- pred %>%
     dplyr::select(-group) %>%
     dplyr::arrange(.row, penalty) %>%
     tidyr::nest(.pred = c(-.row)) %>%


### PR DESCRIPTION
Fixes: 

``` r
# pak::pak("tidyverse/dplyr")
library(censored)
#> Loading required package: parsnip
#> Loading required package: survival
  
lung2 <- lung[-14, ]
new_data_3 <- lung2[1:3, ]

cox_spec <- proportional_hazards(penalty = 0.123) %>% set_engine("glmnet")


f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung2)


pred_multi <- multi_predict(f_fit, new_data_3, type = "linear_pred",
                            penalty = c(0.05, 0.1))
#> Warning: Each row in `x` should match at most 1 row in `y`.
#> ℹ Row 1 of `x` matches multiple rows.
#> ℹ If multiple matches are expected, specify `multiple = "all"` in the join call
#>   to silence this warning.
```

<sup>Created on 2022-07-21 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Description + links to related issues in https://gist.github.com/simonpcouch/b47e618fa6ebac6ed4995765169a87bb. :)