### PR TITLE
tidy up for pkgdown site

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,6 @@ Suggests:
     testthat (>= 3.0.0)
 Config/Needs/website:
     tidymodels,
-    tidymodels/parsnip,
     tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/vignettes/articles/template-lung.R
+++ b/vignettes/articles/template-lung.R
@@ -3,7 +3,6 @@
 #+ results = "hide", messages = FALSE
 library(tidymodels)
 library(censored)
-library(survival)
 tidymodels_prefer()
 
 data(cancer)


### PR DESCRIPTION
We shouldn't need the dev version of parsnip anymore since the new mode etc is on CRAN now. We also don't need to load the survival pkg in addition to censored anymore.