### PR TITLE
Consistent order of topics in test files

### DIFF
--- a/tests/testthat/test-boost_tree-mboost.R
+++ b/tests/testthat/test-boost_tree-mboost.R
@@ -23,6 +23,29 @@ test_that("model object", {
   )
 })
 
+# prediction: time --------------------------------------------------------
+
+test_that("time predictions", {
+  cox_spec <- boost_tree() %>%
+    set_engine("mboost") %>%
+    set_mode("censored regression")
+  f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung)
+
+  f_pred <- predict(f_fit, lung, type = "time")
+
+  expect_s3_class(f_pred, "tbl_df")
+  expect_true(all(names(f_pred) == ".pred_time"))
+  expect_equal(nrow(f_pred), nrow(lung))
+
+  # single observation
+  # skip until mboost::survFit() works with a single row for `newdata`
+  # fix submitted: https://github.com/boost-R/mboost/pull/118
+  # expect_error(f_pred_1 <- predict(f_fit, lung[1,], type = "time"), NA)
+  # expect_equal(nrow(f_pred_1), 1)
+})
+
+
+# prediction: survival ----------------------------------------------------
 
 test_that("survival predictions", {
   pred_time <- c(0, 100, 200, 10000)
@@ -62,6 +85,9 @@ test_that("survival predictions", {
   )
 })
 
+
+# prediction: linear_pred -------------------------------------------------
+
 test_that("linear_pred predictions", {
   lung2 <- lung[-14, ]
   exp_f_fit <- mboost::blackboost(Surv(time, status) ~ age + ph.ecog,
@@ -91,21 +117,3 @@ test_that("linear_pred predictions", {
 })
 
 
-test_that("time predictions", {
-  cox_spec <- boost_tree() %>%
-    set_engine("mboost") %>%
-    set_mode("censored regression")
-  f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung)
-
-  f_pred <- predict(f_fit, lung, type = "time")
-
-  expect_s3_class(f_pred, "tbl_df")
-  expect_true(all(names(f_pred) == ".pred_time"))
-  expect_equal(nrow(f_pred), nrow(lung))
-
-  # single observation
-  # skip until mboost::survFit() works with a single row for `newdata`
-  # fix submitted: https://github.com/boost-R/mboost/pull/118
-  # expect_error(f_pred_1 <- predict(f_fit, lung[1,], type = "time"), NA)
-  # expect_equal(nrow(f_pred_1), 1)
-})

--- a/tests/testthat/test-decision_tree-partykit.R
+++ b/tests/testthat/test-decision_tree-partykit.R
@@ -27,6 +27,8 @@ test_that("model object", {
 })
 
 
+# prediction: time --------------------------------------------------------
+
 test_that("time predictions", {
   skip_if_not_installed("partykit")
   set.seed(1234)
@@ -47,6 +49,8 @@ test_that("time predictions", {
   expect_equal(nrow(f_pred), nrow(lung))
 })
 
+
+# prediction: survival ----------------------------------------------------
 
 test_that("survival predictions", {
   skip_if_not_installed("partykit")

--- a/tests/testthat/test-decision_tree-rpart.R
+++ b/tests/testthat/test-decision_tree-rpart.R
@@ -17,6 +17,9 @@ test_that("model object", {
   expect_equal(f_fit$fit, exp_f_fit, ignore_formula_env = TRUE)
 })
 
+
+# prediction: time --------------------------------------------------------
+
 test_that("time predictions", {
   set.seed(1234)
   exp_f_fit <- pec::pecRpart(Surv(time, status) ~ age + ph.ecog, data = lung)
@@ -35,6 +38,9 @@ test_that("time predictions", {
   expect_equal(f_pred$.pred_time, unname(exp_f_pred))
   expect_equal(nrow(f_pred), nrow(lung))
 })
+
+
+# prediction: survival ----------------------------------------------------
 
 test_that("survival predictions", {
   set.seed(1234)

--- a/tests/testthat/test-proportional_hazards-glmnet.R
+++ b/tests/testthat/test-proportional_hazards-glmnet.R
@@ -18,157 +18,193 @@ test_that("model object", {
   expect_equal(f_fit$fit[-11], exp_f_fit[-11])
 })
 
-# prediction: linear_pred -------------------------------------------------
 
-test_that("linear_pred predictions without strata", {
+# prediction: time --------------------------------------------------------
+
+test_that("time predictions without strata", {
+
+  # remove row with missing value in ph.ecog
   lung2 <- lung[-14, ]
-  exp_f_fit <- glmnet(x = as.matrix(lung2[, c(4, 6)]),
-                      y = Surv(lung2$time, lung2$status),
-                      family = "cox")
-  cox_spec <- proportional_hazards(penalty = 0.123) %>% set_engine("glmnet")
+  new_data_3 <- lung2[1:3, ]
+
+  lung_x <- as.matrix(lung2[, c("age", "ph.ecog")])
+  lung_y <- Surv(lung2$time, lung2$status)
+  new_x <- as.matrix(lung2[1:3, c("age", "ph.ecog")])
+  set.seed(14)
+  exp_f <- glmnet::glmnet(lung_x, lung_y, family = "cox")
+  exp_sf <- survfit(exp_f, newx = new_x, x = lung_x, y = lung_y, s = 0.1)
+  exp_f_pred <- summary(exp_sf)$table[, "rmean"] %>% unname()
+
+  cox_spec <- proportional_hazards(penalty = 0.123) %>%
+    set_mode("censored regression") %>%
+    set_engine("glmnet")
+  set.seed(14)
   f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung2)
 
   # predict
-  f_pred <- predict(f_fit, lung2, type = "linear_pred", penalty = 0.01)
-  exp_f_pred <- -unname(predict(exp_f_fit, newx = as.matrix(lung2[, c(4, 6)]),
-                                s = 0.01))
+  new_data_3 <- lung2[1:3, ]
+  # should default to penalty value specified at fit time
+  expect_error(
+    f_pred <- predict(f_fit, new_data = new_data_3, type = "time"),
+    NA
+  )
+  f_pred <- predict(f_fit, new_data = new_data_3, type = "time", penalty = 0.1)
 
   expect_s3_class(f_pred, "tbl_df")
-  expect_true(all(names(f_pred) == ".pred_linear_pred"))
-  expect_equal(f_pred$.pred_linear_pred, as.vector(exp_f_pred))
-  expect_equal(nrow(f_pred), nrow(lung2))
+  expect_true(all(names(f_pred) == ".pred_time"))
+  expect_equal(nrow(f_pred), nrow(new_data_3))
+  expect_equal(f_pred$.pred_time, exp_f_pred)
 
   # single observation
-  expect_error(f_pred_1 <- predict(f_fit, lung2[1,], type = "linear_pred"), NA)
+  f_pred_1 <- predict(f_fit, lung2[1,], type = "time")
   expect_equal(nrow(f_pred_1), 1)
 
-  # predict without the sign flip
-  f_pred <- predict(f_fit, lung2, type = "linear_pred", penalty = 0.01, increasing = FALSE)
-  exp_f_pred <- unname(predict(exp_f_fit, newx = as.matrix(lung2[, c(4, 6)]), s = 0.01))
-
-  expect_s3_class(f_pred, "tbl_df")
-  expect_true(all(names(f_pred) == ".pred_linear_pred"))
-  expect_equal(f_pred$.pred_linear_pred, as.vector(exp_f_pred))
-  expect_equal(nrow(f_pred), nrow(lung2))
-
-
-  # multi_predict
-  new_data_3 <- lung2[1:3, ]
-  f_pred_unnested_01 <-
-    predict(f_fit, new_data_3, type = "linear_pred", penalty = 0.1) %>%
-    dplyr::mutate(penalty = 0.1, .row = seq_len(nrow(new_data_3)))
-  f_pred_unnested_005 <-
-    predict(f_fit, new_data_3, type = "linear_pred", penalty = 0.05) %>%
-    dplyr::mutate(penalty = 0.05, .row = seq_len(nrow(new_data_3)))
-  exp_pred_multi_unnested <-
-    dplyr::bind_rows(
-      f_pred_unnested_005,
-      f_pred_unnested_01
-    ) %>%
-    dplyr::arrange(.row, penalty) %>%
-    dplyr::select(penalty, .pred_linear_pred) %>%
-    dplyr::mutate(.pred_linear_pred = -.pred_linear_pred)
-
-  pred_multi <- multi_predict(f_fit, new_data_3, type = "linear_pred",
-                              penalty = c(0.05, 0.1))
-  expect_s3_class(pred_multi, "tbl_df")
-  expect_equal(names(pred_multi), ".pred")
-  expect_equal(nrow(pred_multi), nrow(new_data_3))
-  expect_true(
-    all(purrr::map_lgl(pred_multi$.pred,
-                       ~ all(dim(.x) == c(2, 2))))
-  )
-  expect_true(
-    all(purrr::map_lgl(pred_multi$.pred,
-                       ~ all(names(.x) == c("penalty", ".pred_linear_pred"))))
-  )
-  expect_equal(
-    pred_multi %>% tidyr::unnest(cols = .pred),
-    exp_pred_multi_unnested
-  )
 })
 
-test_that("linear_pred predictions with strata", {
+test_that("time predictions with strata", {
 
-  # TODO find a better example?
-
+  # remove row with missing value in ph.ecog
   lung2 <- lung[-14, ]
-  exp_f_fit <- suppressWarnings(
-    glmnet(x = as.matrix(lung2[, c(4, 6)]),
-           y = stratifySurv(Surv(lung2$time, lung2$status), lung2$sex),
-           family = "cox")
+  new_data_3 <- lung2[1:3, ]
+
+  lung_x <- as.matrix(lung2[, c("age", "ph.ecog")])
+  lung_y <- Surv(lung2$time, lung2$status) %>%
+    glmnet::stratifySurv(lung2$sex)
+  new_x <- as.matrix(lung2[1:3, c("age", "ph.ecog")])
+  new_strata <- lung2$sex[1:3]
+  set.seed(14)
+  suppressWarnings(
+    exp_f <- glmnet::glmnet(lung_x, lung_y, family = "cox")
   )
-  cox_spec <- proportional_hazards(penalty = 0.123) %>% set_engine("glmnet")
-  expect_error(
-    suppressWarnings(
-      f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog + strata(sex),
+  exp_sf <- survfit(exp_f, newx = new_x, newstrata = new_strata,
+                    x = lung_x, y = lung_y, s = 0.1)
+  exp_f_pred <- summary(exp_sf)$table[, "rmean"] %>% unname()
+
+  cox_spec <- proportional_hazards(penalty = 0.123) %>%
+    set_mode("censored regression") %>%
+    set_engine("glmnet")
+  set.seed(14)
+  suppressWarnings(
+    f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog + strata(sex),
                  data = lung2)
-    ),
-    NA
   )
 
   # predict
-  f_pred <- predict(f_fit, lung2, type = "linear_pred", penalty = 0.01)
-  exp_f_pred <- -unname(predict(exp_f_fit, newx = as.matrix(lung2[, c(4, 6)]), s = 0.01))
+  new_data_3 <- lung2[1:3, ]
+  # should default to penalty value specified at fit time
+  expect_error(
+    f_pred <- predict(f_fit, new_data = new_data_3, type = "time"),
+    NA
+  )
+  f_pred <- predict(f_fit, new_data = new_data_3, type = "time", penalty = 0.1)
 
   expect_s3_class(f_pred, "tbl_df")
-  expect_true(all(names(f_pred) == ".pred_linear_pred"))
-  expect_equal(f_pred$.pred_linear_pred, as.vector(exp_f_pred))
-  expect_equal(nrow(f_pred), nrow(lung2))
+  expect_true(all(names(f_pred) == ".pred_time"))
+  expect_equal(nrow(f_pred), nrow(new_data_3))
+  expect_equal(f_pred$.pred_time, exp_f_pred)
 
   # single observation
-  expect_error(f_pred_1 <- predict(f_fit, lung2[1,], type = "linear_pred"), NA)
+  f_pred_1 <- predict(f_fit, lung2[1,], type = "time")
   expect_equal(nrow(f_pred_1), 1)
 
-  # predict without the sign flip
-  f_pred <- predict(f_fit, lung2, type = "linear_pred", penalty = 0.01, increasing = FALSE)
-  exp_f_pred <- unname(predict(exp_f_fit, newx = as.matrix(lung2[, c(4, 6)]), s = 0.01))
+})
 
-  expect_s3_class(f_pred, "tbl_df")
-  expect_true(all(names(f_pred) == ".pred_linear_pred"))
-  expect_equal(f_pred$.pred_linear_pred, as.vector(exp_f_pred))
-  expect_equal(nrow(f_pred), nrow(lung2))
+test_that("time predictions with NA in predictor", {
 
+  lung2 <- lung[-14,]
 
-  # multi_predict
-  new_data_3 <- lung2[1:3, ]
-  f_pred_unnested_01 <-
-    predict(f_fit, new_data_3, type = "linear_pred", penalty = 0.1) %>%
-    dplyr::mutate(penalty = 0.1, .row = seq_len(nrow(new_data_3)))
-  f_pred_unnested_005 <-
-    predict(f_fit, new_data_3, type = "linear_pred", penalty = 0.05) %>%
-    dplyr::mutate(penalty = 0.05, .row = seq_len(nrow(new_data_3)))
-  exp_pred_multi_unnested <-
-    dplyr::bind_rows(
-      f_pred_unnested_005,
-      f_pred_unnested_01
-    ) %>%
-    dplyr::arrange(.row, penalty) %>%
-    dplyr::select(penalty, .pred_linear_pred) %>%
-    dplyr::mutate(.pred_linear_pred = -.pred_linear_pred)
-
-  pred_multi <- multi_predict(f_fit, new_data_3, type = "linear_pred",
-                              penalty = c(0.05, 0.1))
-  expect_s3_class(pred_multi, "tbl_df")
-  expect_equal(names(pred_multi), ".pred")
-  expect_equal(nrow(pred_multi), nrow(new_data_3))
-  expect_true(
-    all(purrr::map_lgl(pred_multi$.pred,
-                       ~ all(dim(.x) == c(2, 2))))
+  suppressWarnings(
+    f_fit <- proportional_hazards(penalty = 0.123) %>%
+      set_engine("glmnet") %>%
+      fit(Surv(time, status) ~ age + ph.ecog + strata(sex), data = lung2)
   )
-  expect_true(
-    all(purrr::map_lgl(pred_multi$.pred,
-                       ~ all(names(.x) == c("penalty", ".pred_linear_pred"))))
+
+  # survfit.coxph() is not type-stable,
+  # thus test against single or multiple survival curves
+  # lung$ph.ecog[14] is NA
+  na_x_data_x <- lung[c(13:15, 14),]
+  na_x_data_1 <- lung[c(13, 14, 14),]
+  na_x_data_0 <- lung[c(14, 14),]
+  na_1_data_x <- lung[13:15,]
+  na_1_data_1 <- lung[13:14,]
+  na_1_data_0 <- lung[14,]
+
+  # survival times
+  f_pred <- predict(f_fit, na_x_data_x, type = "time")
+  expect_equal(nrow(f_pred), nrow(na_x_data_x))
+  expect_identical(which(is.na(f_pred$.pred_time)), c(2L,4L))
+
+  f_pred <- predict(f_fit, na_x_data_1, type = "time")
+  expect_equal(nrow(f_pred), nrow(na_x_data_1))
+  expect_identical(which(is.na(f_pred$.pred_time)), c(2L,3L))
+
+  f_pred <- predict(f_fit, na_x_data_0, type = "time")
+  expect_equal(nrow(f_pred), nrow(na_x_data_0))
+  expect_identical(which(is.na(f_pred$.pred_time)), c(1L,2L))
+
+  f_pred <- predict(f_fit, na_1_data_x, type = "time")
+  expect_equal(nrow(f_pred), nrow(na_1_data_x))
+  expect_identical(which(is.na(f_pred$.pred_time)), 2L)
+
+  f_pred <- predict(f_fit, na_1_data_1, type = "time")
+  expect_equal(nrow(f_pred), nrow(na_1_data_1))
+  expect_identical(which(is.na(f_pred$.pred_time)), 2L)
+
+  f_pred <- predict(f_fit, na_1_data_0, type = "time")
+  expect_equal(nrow(f_pred), nrow(na_1_data_0))
+  expect_identical(which(is.na(f_pred$.pred_time)), 1L)
+
+})
+
+test_that("time predictions with NA in strata", {
+
+  lung2 <- lung[-14,]
+
+  suppressWarnings(
+    f_fit <- proportional_hazards(penalty = 0.123) %>%
+      set_engine("glmnet") %>%
+      fit(Surv(time, status) ~ age + ph.ecog + strata(sex), data = lung2)
   )
-  expect_equal(
-    pred_multi %>% tidyr::unnest(cols = .pred),
-    exp_pred_multi_unnested
-  )
+
+  # survfit.coxph() is not type-stable,
+  # thus test against single or multiple survival curves
+  lung2$sex[2] <- NA
+  na_x_data_x <- lung2[c(1:3, 2),]
+  na_x_data_1 <- lung2[c(1, 2, 2),]
+  na_x_data_0 <- lung2[c(2, 2),]
+  na_1_data_x <- lung2[1:3,]
+  na_1_data_1 <- lung2[1:2,]
+  na_1_data_0 <- lung2[2,]
+
+  # survival times
+  f_pred <- predict(f_fit, na_x_data_x, type = "time")
+  expect_equal(nrow(f_pred), nrow(na_x_data_x))
+  expect_identical(which(is.na(f_pred$.pred_time)), c(2L,4L))
+
+  f_pred <- predict(f_fit, na_x_data_1, type = "time")
+  expect_equal(nrow(f_pred), nrow(na_x_data_1))
+  expect_identical(which(is.na(f_pred$.pred_time)), c(2L,3L))
+
+  f_pred <- predict(f_fit, na_x_data_0, type = "time")
+  expect_equal(nrow(f_pred), nrow(na_x_data_0))
+  expect_identical(which(is.na(f_pred$.pred_time)), c(1L,2L))
+
+  f_pred <- predict(f_fit, na_1_data_x, type = "time")
+  expect_equal(nrow(f_pred), nrow(na_1_data_x))
+  expect_identical(which(is.na(f_pred$.pred_time)), 2L)
+
+  f_pred <- predict(f_fit, na_1_data_1, type = "time")
+  expect_equal(nrow(f_pred), nrow(na_1_data_1))
+  expect_identical(which(is.na(f_pred$.pred_time)), 2L)
+
+  f_pred <- predict(f_fit, na_1_data_0, type = "time")
+  expect_equal(nrow(f_pred), nrow(na_1_data_0))
+  expect_identical(which(is.na(f_pred$.pred_time)), 1L)
+
 })
 
 
-
-# prediction: survival probabilities -------------------------------------
+# prediction: survival ----------------------------------------------------
 
 test_that("survival probabilities without strata", {
 
@@ -459,192 +495,153 @@ test_that("survival prediction with NA in strata", {
 
 })
 
+# prediction: linear_pred -------------------------------------------------
 
-
-# prediction: time --------------------------------------------------------
-
-test_that("time predictions without strata", {
-
-  # remove row with missing value in ph.ecog
+test_that("linear_pred predictions without strata", {
   lung2 <- lung[-14, ]
-  new_data_3 <- lung2[1:3, ]
-
-  lung_x <- as.matrix(lung2[, c("age", "ph.ecog")])
-  lung_y <- Surv(lung2$time, lung2$status)
-  new_x <- as.matrix(lung2[1:3, c("age", "ph.ecog")])
-  set.seed(14)
-  exp_f <- glmnet::glmnet(lung_x, lung_y, family = "cox")
-  exp_sf <- survfit(exp_f, newx = new_x, x = lung_x, y = lung_y, s = 0.1)
-  exp_f_pred <- summary(exp_sf)$table[, "rmean"] %>% unname()
-
-  cox_spec <- proportional_hazards(penalty = 0.123) %>%
-    set_mode("censored regression") %>%
-    set_engine("glmnet")
-  set.seed(14)
+  exp_f_fit <- glmnet(x = as.matrix(lung2[, c(4, 6)]),
+                      y = Surv(lung2$time, lung2$status),
+                      family = "cox")
+  cox_spec <- proportional_hazards(penalty = 0.123) %>% set_engine("glmnet")
   f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung2)
 
   # predict
-  new_data_3 <- lung2[1:3, ]
-  # should default to penalty value specified at fit time
-  expect_error(
-    f_pred <- predict(f_fit, new_data = new_data_3, type = "time"),
-    NA
-  )
-  f_pred <- predict(f_fit, new_data = new_data_3, type = "time", penalty = 0.1)
+  f_pred <- predict(f_fit, lung2, type = "linear_pred", penalty = 0.01)
+  exp_f_pred <- -unname(predict(exp_f_fit, newx = as.matrix(lung2[, c(4, 6)]),
+                                s = 0.01))
 
   expect_s3_class(f_pred, "tbl_df")
-  expect_true(all(names(f_pred) == ".pred_time"))
-  expect_equal(nrow(f_pred), nrow(new_data_3))
-  expect_equal(f_pred$.pred_time, exp_f_pred)
+  expect_true(all(names(f_pred) == ".pred_linear_pred"))
+  expect_equal(f_pred$.pred_linear_pred, as.vector(exp_f_pred))
+  expect_equal(nrow(f_pred), nrow(lung2))
 
   # single observation
-  f_pred_1 <- predict(f_fit, lung2[1,], type = "time")
+  expect_error(f_pred_1 <- predict(f_fit, lung2[1,], type = "linear_pred"), NA)
   expect_equal(nrow(f_pred_1), 1)
 
+  # predict without the sign flip
+  f_pred <- predict(f_fit, lung2, type = "linear_pred", penalty = 0.01, increasing = FALSE)
+  exp_f_pred <- unname(predict(exp_f_fit, newx = as.matrix(lung2[, c(4, 6)]), s = 0.01))
+
+  expect_s3_class(f_pred, "tbl_df")
+  expect_true(all(names(f_pred) == ".pred_linear_pred"))
+  expect_equal(f_pred$.pred_linear_pred, as.vector(exp_f_pred))
+  expect_equal(nrow(f_pred), nrow(lung2))
+
+
+  # multi_predict
+  new_data_3 <- lung2[1:3, ]
+  f_pred_unnested_01 <-
+    predict(f_fit, new_data_3, type = "linear_pred", penalty = 0.1) %>%
+    dplyr::mutate(penalty = 0.1, .row = seq_len(nrow(new_data_3)))
+  f_pred_unnested_005 <-
+    predict(f_fit, new_data_3, type = "linear_pred", penalty = 0.05) %>%
+    dplyr::mutate(penalty = 0.05, .row = seq_len(nrow(new_data_3)))
+  exp_pred_multi_unnested <-
+    dplyr::bind_rows(
+      f_pred_unnested_005,
+      f_pred_unnested_01
+    ) %>%
+    dplyr::arrange(.row, penalty) %>%
+    dplyr::select(penalty, .pred_linear_pred) %>%
+    dplyr::mutate(.pred_linear_pred = -.pred_linear_pred)
+
+  pred_multi <- multi_predict(f_fit, new_data_3, type = "linear_pred",
+                              penalty = c(0.05, 0.1))
+  expect_s3_class(pred_multi, "tbl_df")
+  expect_equal(names(pred_multi), ".pred")
+  expect_equal(nrow(pred_multi), nrow(new_data_3))
+  expect_true(
+    all(purrr::map_lgl(pred_multi$.pred,
+                       ~ all(dim(.x) == c(2, 2))))
+  )
+  expect_true(
+    all(purrr::map_lgl(pred_multi$.pred,
+                       ~ all(names(.x) == c("penalty", ".pred_linear_pred"))))
+  )
+  expect_equal(
+    pred_multi %>% tidyr::unnest(cols = .pred),
+    exp_pred_multi_unnested
+  )
 })
 
-test_that("time predictions with strata", {
+test_that("linear_pred predictions with strata", {
 
-  # remove row with missing value in ph.ecog
+  # TODO find a better example?
+
   lung2 <- lung[-14, ]
-  new_data_3 <- lung2[1:3, ]
-
-  lung_x <- as.matrix(lung2[, c("age", "ph.ecog")])
-  lung_y <- Surv(lung2$time, lung2$status) %>%
-    glmnet::stratifySurv(lung2$sex)
-  new_x <- as.matrix(lung2[1:3, c("age", "ph.ecog")])
-  new_strata <- lung2$sex[1:3]
-  set.seed(14)
-  suppressWarnings(
-    exp_f <- glmnet::glmnet(lung_x, lung_y, family = "cox")
+  exp_f_fit <- suppressWarnings(
+    glmnet(x = as.matrix(lung2[, c(4, 6)]),
+           y = stratifySurv(Surv(lung2$time, lung2$status), lung2$sex),
+           family = "cox")
   )
-  exp_sf <- survfit(exp_f, newx = new_x, newstrata = new_strata,
-                    x = lung_x, y = lung_y, s = 0.1)
-  exp_f_pred <- summary(exp_sf)$table[, "rmean"] %>% unname()
-
-  cox_spec <- proportional_hazards(penalty = 0.123) %>%
-    set_mode("censored regression") %>%
-    set_engine("glmnet")
-  set.seed(14)
-  suppressWarnings(
-    f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog + strata(sex),
-                 data = lung2)
+  cox_spec <- proportional_hazards(penalty = 0.123) %>% set_engine("glmnet")
+  expect_error(
+    suppressWarnings(
+      f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog + strata(sex),
+                   data = lung2)
+    ),
+    NA
   )
 
   # predict
-  new_data_3 <- lung2[1:3, ]
-  # should default to penalty value specified at fit time
-  expect_error(
-    f_pred <- predict(f_fit, new_data = new_data_3, type = "time"),
-    NA
-  )
-  f_pred <- predict(f_fit, new_data = new_data_3, type = "time", penalty = 0.1)
+  f_pred <- predict(f_fit, lung2, type = "linear_pred", penalty = 0.01)
+  exp_f_pred <- -unname(predict(exp_f_fit, newx = as.matrix(lung2[, c(4, 6)]), s = 0.01))
 
   expect_s3_class(f_pred, "tbl_df")
-  expect_true(all(names(f_pred) == ".pred_time"))
-  expect_equal(nrow(f_pred), nrow(new_data_3))
-  expect_equal(f_pred$.pred_time, exp_f_pred)
+  expect_true(all(names(f_pred) == ".pred_linear_pred"))
+  expect_equal(f_pred$.pred_linear_pred, as.vector(exp_f_pred))
+  expect_equal(nrow(f_pred), nrow(lung2))
 
   # single observation
-  f_pred_1 <- predict(f_fit, lung2[1,], type = "time")
+  expect_error(f_pred_1 <- predict(f_fit, lung2[1,], type = "linear_pred"), NA)
   expect_equal(nrow(f_pred_1), 1)
 
-})
+  # predict without the sign flip
+  f_pred <- predict(f_fit, lung2, type = "linear_pred", penalty = 0.01, increasing = FALSE)
+  exp_f_pred <- unname(predict(exp_f_fit, newx = as.matrix(lung2[, c(4, 6)]), s = 0.01))
 
-test_that("time predictions with NA in predictor", {
+  expect_s3_class(f_pred, "tbl_df")
+  expect_true(all(names(f_pred) == ".pred_linear_pred"))
+  expect_equal(f_pred$.pred_linear_pred, as.vector(exp_f_pred))
+  expect_equal(nrow(f_pred), nrow(lung2))
 
-  lung2 <- lung[-14,]
 
-  suppressWarnings(
-    f_fit <- proportional_hazards(penalty = 0.123) %>%
-      set_engine("glmnet") %>%
-      fit(Surv(time, status) ~ age + ph.ecog + strata(sex), data = lung2)
+  # multi_predict
+  new_data_3 <- lung2[1:3, ]
+  f_pred_unnested_01 <-
+    predict(f_fit, new_data_3, type = "linear_pred", penalty = 0.1) %>%
+    dplyr::mutate(penalty = 0.1, .row = seq_len(nrow(new_data_3)))
+  f_pred_unnested_005 <-
+    predict(f_fit, new_data_3, type = "linear_pred", penalty = 0.05) %>%
+    dplyr::mutate(penalty = 0.05, .row = seq_len(nrow(new_data_3)))
+  exp_pred_multi_unnested <-
+    dplyr::bind_rows(
+      f_pred_unnested_005,
+      f_pred_unnested_01
+    ) %>%
+    dplyr::arrange(.row, penalty) %>%
+    dplyr::select(penalty, .pred_linear_pred) %>%
+    dplyr::mutate(.pred_linear_pred = -.pred_linear_pred)
+
+  pred_multi <- multi_predict(f_fit, new_data_3, type = "linear_pred",
+                              penalty = c(0.05, 0.1))
+  expect_s3_class(pred_multi, "tbl_df")
+  expect_equal(names(pred_multi), ".pred")
+  expect_equal(nrow(pred_multi), nrow(new_data_3))
+  expect_true(
+    all(purrr::map_lgl(pred_multi$.pred,
+                       ~ all(dim(.x) == c(2, 2))))
   )
-
-  # survfit.coxph() is not type-stable,
-  # thus test against single or multiple survival curves
-  # lung$ph.ecog[14] is NA
-  na_x_data_x <- lung[c(13:15, 14),]
-  na_x_data_1 <- lung[c(13, 14, 14),]
-  na_x_data_0 <- lung[c(14, 14),]
-  na_1_data_x <- lung[13:15,]
-  na_1_data_1 <- lung[13:14,]
-  na_1_data_0 <- lung[14,]
-
-  # survival times
-  f_pred <- predict(f_fit, na_x_data_x, type = "time")
-  expect_equal(nrow(f_pred), nrow(na_x_data_x))
-  expect_identical(which(is.na(f_pred$.pred_time)), c(2L,4L))
-
-  f_pred <- predict(f_fit, na_x_data_1, type = "time")
-  expect_equal(nrow(f_pred), nrow(na_x_data_1))
-  expect_identical(which(is.na(f_pred$.pred_time)), c(2L,3L))
-
-  f_pred <- predict(f_fit, na_x_data_0, type = "time")
-  expect_equal(nrow(f_pred), nrow(na_x_data_0))
-  expect_identical(which(is.na(f_pred$.pred_time)), c(1L,2L))
-
-  f_pred <- predict(f_fit, na_1_data_x, type = "time")
-  expect_equal(nrow(f_pred), nrow(na_1_data_x))
-  expect_identical(which(is.na(f_pred$.pred_time)), 2L)
-
-  f_pred <- predict(f_fit, na_1_data_1, type = "time")
-  expect_equal(nrow(f_pred), nrow(na_1_data_1))
-  expect_identical(which(is.na(f_pred$.pred_time)), 2L)
-
-  f_pred <- predict(f_fit, na_1_data_0, type = "time")
-  expect_equal(nrow(f_pred), nrow(na_1_data_0))
-  expect_identical(which(is.na(f_pred$.pred_time)), 1L)
-
-})
-
-test_that("time predictions with NA in strata", {
-
-  lung2 <- lung[-14,]
-
-  suppressWarnings(
-    f_fit <- proportional_hazards(penalty = 0.123) %>%
-      set_engine("glmnet") %>%
-      fit(Surv(time, status) ~ age + ph.ecog + strata(sex), data = lung2)
+  expect_true(
+    all(purrr::map_lgl(pred_multi$.pred,
+                       ~ all(names(.x) == c("penalty", ".pred_linear_pred"))))
   )
-
-  # survfit.coxph() is not type-stable,
-  # thus test against single or multiple survival curves
-  lung2$sex[2] <- NA
-  na_x_data_x <- lung2[c(1:3, 2),]
-  na_x_data_1 <- lung2[c(1, 2, 2),]
-  na_x_data_0 <- lung2[c(2, 2),]
-  na_1_data_x <- lung2[1:3,]
-  na_1_data_1 <- lung2[1:2,]
-  na_1_data_0 <- lung2[2,]
-
-  # survival times
-  f_pred <- predict(f_fit, na_x_data_x, type = "time")
-  expect_equal(nrow(f_pred), nrow(na_x_data_x))
-  expect_identical(which(is.na(f_pred$.pred_time)), c(2L,4L))
-
-  f_pred <- predict(f_fit, na_x_data_1, type = "time")
-  expect_equal(nrow(f_pred), nrow(na_x_data_1))
-  expect_identical(which(is.na(f_pred$.pred_time)), c(2L,3L))
-
-  f_pred <- predict(f_fit, na_x_data_0, type = "time")
-  expect_equal(nrow(f_pred), nrow(na_x_data_0))
-  expect_identical(which(is.na(f_pred$.pred_time)), c(1L,2L))
-
-  f_pred <- predict(f_fit, na_1_data_x, type = "time")
-  expect_equal(nrow(f_pred), nrow(na_1_data_x))
-  expect_identical(which(is.na(f_pred$.pred_time)), 2L)
-
-  f_pred <- predict(f_fit, na_1_data_1, type = "time")
-  expect_equal(nrow(f_pred), nrow(na_1_data_1))
-  expect_identical(which(is.na(f_pred$.pred_time)), 2L)
-
-  f_pred <- predict(f_fit, na_1_data_0, type = "time")
-  expect_equal(nrow(f_pred), nrow(na_1_data_0))
-  expect_identical(which(is.na(f_pred$.pred_time)), 1L)
-
+  expect_equal(
+    pred_multi %>% tidyr::unnest(cols = .pred),
+    exp_pred_multi_unnested
+  )
 })
-
 
 
 # helper functions --------------------------------------------------------

--- a/tests/testthat/test-proportional_hazards-survival.R
+++ b/tests/testthat/test-proportional_hazards-survival.R
@@ -136,7 +136,7 @@ test_that("time predictions with NA", {
 })
 
 
-# prediction: survival probabilities --------------------------------------
+# prediction: survival ----------------------------------------------------
 
 test_that("survival predictions without strata", {
   cox_spec <- proportional_hazards() %>% set_engine("survival")

--- a/tests/testthat/test-rand_forest-partykit.R
+++ b/tests/testthat/test-rand_forest-partykit.R
@@ -31,6 +31,9 @@ test_that("model object", {
   )
 })
 
+
+# prediction: time --------------------------------------------------------
+
 test_that("time predictions", {
   skip_if_not_installed("partykit")
 
@@ -56,6 +59,9 @@ test_that("time predictions", {
   expect_equal(f_pred$.pred_time, unname(exp_f_pred))
   expect_equal(nrow(f_pred), nrow(lung))
 })
+
+
+# prediction: survival ----------------------------------------------------
 
 test_that("survival predictions", {
   skip_if_not_installed("partykit")

--- a/tests/testthat/test-survival_reg-flexsurv.R
+++ b/tests/testthat/test-survival_reg-flexsurv.R
@@ -1,6 +1,5 @@
 library(testthat)
 
-
 test_that("model object", {
   set.seed(1234)
   exp_f_fit <- flexsurv::flexsurvreg(
@@ -26,6 +25,9 @@ test_that("model object", {
   )
 })
 
+
+# prediction: time --------------------------------------------------------
+
 test_that("flexsurv time prediction", {
   exp_fit <- flexsurv::flexsurvreg(Surv(time, status) ~ age, data = lung,
                                    dist = "lognormal")
@@ -39,6 +41,8 @@ test_that("flexsurv time prediction", {
   expect_equal(f_pred, exp_pred)
 })
 
+
+# prediction: survival ----------------------------------------------------
 
 test_that("survival probability prediction", {
   rms_surv <- readRDS(test_path("data", "rms_surv.rds"))
@@ -87,42 +91,29 @@ test_that("survival probability prediction", {
   )
 })
 
+# prediction: linear_pred -------------------------------------------------
 
-test_that("hazard prediction", {
-  rms_haz <- readRDS(test_path("data", "rms_haz.rds"))
-  f_fit <- survival_reg(dist = "weibull") %>%
+test_that("linear predictor", {
+  f_fit <- survival_reg() %>%
     set_engine("flexsurv") %>%
     fit(Surv(time, status) ~ age + sex, data = lung)
+  f_pred <- predict(f_fit, lung[1:5,], type = "linear_pred")
 
-  expect_error(
-    predict(f_fit, head(lung), type = "hazard"),
-    "a numeric vector 'time'"
+  exp_fit <- flexsurv::flexsurvreg(
+    Surv(time, status) ~ age + sex,
+    data = lung,
+    dist = "weibull"
   )
-
-  f_pred <- predict(f_fit, head(lung), type = "hazard",
-                      time = c(0, 500, 1000))
+  exp_pred <- predict(exp_fit, lung[1:5,], type = "linear")
 
   expect_s3_class(f_pred, "tbl_df")
-  expect_equal(names(f_pred), ".pred")
-  expect_equal(nrow(f_pred), nrow(head(lung)))
-  expect_true(
-    all(purrr::map_lgl(f_pred$.pred,
-                       ~ all(dim(.x) == c(3, 2))))
-  )
-  expect_true(
-    all(
-      purrr::map_lgl(
-        f_pred$.pred,
-        ~ all(names(.x) == c(".time", ".pred_hazard"))))
-  )
-
-  # using rms for expected results
-  expect_equal(
-    f_pred$.pred[[1]]$.pred_hazard,
-    rms_haz,
-    tolerance = 0.001
-    )
+  expect_true(all(names(f_pred) == ".pred_linear_pred"))
+  expect_equal(f_pred$.pred_linear_pred, log(exp_pred$.pred_link))
+  expect_equal(nrow(f_pred), 5)
 })
+
+
+# prediction: quantile ----------------------------------------------------
 
 test_that("quantile predictions", {
   set.seed(1)
@@ -175,21 +166,40 @@ test_that("quantile predictions", {
 
 })
 
-test_that("linear predictor", {
-  f_fit <- survival_reg() %>%
+# prediction: hazard ------------------------------------------------------
+
+test_that("hazard prediction", {
+  rms_haz <- readRDS(test_path("data", "rms_haz.rds"))
+  f_fit <- survival_reg(dist = "weibull") %>%
     set_engine("flexsurv") %>%
     fit(Surv(time, status) ~ age + sex, data = lung)
-  f_pred <- predict(f_fit, lung[1:5,], type = "linear_pred")
 
-  exp_fit <- flexsurv::flexsurvreg(
-    Surv(time, status) ~ age + sex,
-    data = lung,
-    dist = "weibull"
-    )
-  exp_pred <- predict(exp_fit, lung[1:5,], type = "linear")
+  expect_error(
+    predict(f_fit, head(lung), type = "hazard"),
+    "a numeric vector 'time'"
+  )
+
+  f_pred <- predict(f_fit, head(lung), type = "hazard",
+                    time = c(0, 500, 1000))
 
   expect_s3_class(f_pred, "tbl_df")
-  expect_true(all(names(f_pred) == ".pred_linear_pred"))
-  expect_equal(f_pred$.pred_linear_pred, log(exp_pred$.pred_link))
-  expect_equal(nrow(f_pred), 5)
+  expect_equal(names(f_pred), ".pred")
+  expect_equal(nrow(f_pred), nrow(head(lung)))
+  expect_true(
+    all(purrr::map_lgl(f_pred$.pred,
+                       ~ all(dim(.x) == c(3, 2))))
+  )
+  expect_true(
+    all(
+      purrr::map_lgl(
+        f_pred$.pred,
+        ~ all(names(.x) == c(".time", ".pred_hazard"))))
+  )
+
+  # using rms for expected results
+  expect_equal(
+    f_pred$.pred[[1]]$.pred_hazard,
+    rms_haz,
+    tolerance = 0.001
+  )
 })


### PR DESCRIPTION
This uses the following order of "topics" across all test files:

* model object
* predictions of type "time"
* predictions of type "survival"
* predictions of type "linear_pred"
* predictions of type "quantile"
* predictions of type "hazard"
* other