### PR TITLE
Use `summary.survfit()` for PH models

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # censored (development version)
 
+* Predictions of survival probabilities for proportional hazards models with 
+  the `"survival"` and `"glmnet"` engines are now calculated by 
+  `summary.survfit()` (#221).
+
 # censored 0.1.1
 
 * For boosted trees with the `"mboost"` engine, survival probabilities can now be predicted for `time = -Inf`. This is always 1. For `time = Inf` this now predicts a survival probability of 0 (#215).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,6 @@
 # censored (development version)
 
-* Predictions of survival probabilities for proportional hazards models with 
-  the `"survival"` and `"glmnet"` engines are now calculated by 
-  `summary.survfit()` (#221).
+* Predictions of survival probabilities for proportional hazards models with the `"survival"` and `"glmnet"` engines are now calculated by `summary.survfit()` (#221).
 
 # censored 0.1.1
 

--- a/tests/testthat/test-proportional_hazards-survival.R
+++ b/tests/testthat/test-proportional_hazards-survival.R
@@ -297,6 +297,119 @@ test_that("survival prediction with NA", {
 
 })
 
+
+
+test_that("survival_prob_coxph() works", {
+
+  mod <- coxph(Surv(time, status) ~ age + ph.ecog, data = lung)
+
+  # time: combination of order, out-of-range, infinite
+  pred_time <- c(-Inf, 0, 100, Inf, 1022, 3000)
+
+  # multiple observations (with 1 missing)
+  lung_pred <- lung[13:15,]
+  surv_fit <- survfit(mod, newdata = lung_pred)
+  surv_fit_summary <- summary(surv_fit, times = pred_time, extend = TRUE)
+
+  prob <- survival_prob_coxph(mod, new_data = lung_pred, time = pred_time)
+  exp_prob <- surv_fit_summary$surv
+
+  prob_na <- prob$.pred[[2]]
+  prob_non_na <- prob$.pred[[3]]
+  exp_prob_non_na <- exp_prob[,2]
+
+  # get missings right
+  expect_true(all(is.na(prob_na$.pred_survival)))
+  # for non-missings, get probs right
+  expect_equal(prob_non_na$.time, pred_time)
+  expect_equal(
+    prob_non_na$.pred_survival[c(1, 4)],
+    c(1, 0)
+  )
+  expect_equal(
+    prob_non_na %>%
+      dplyr::filter(is.finite(.time)) %>%
+      dplyr::arrange(.time) %>%
+      dplyr::pull(.pred_survival),
+    exp_prob_non_na
+  )
+
+  # single observation
+  lung_pred <- lung[13,]
+  surv_fit <- survfit(mod, newdata = lung_pred)
+  surv_fit_summary <- summary(surv_fit, times = pred_time, extend = TRUE)
+
+  prob <- survival_prob_coxph(mod, new_data = lung_pred, time = pred_time)
+  prob <- tidyr::unnest(prob, cols = .pred)
+  exp_prob <- surv_fit_summary$surv
+
+  expect_equal(
+    prob$.pred_survival[c(1, 4)],
+    c(1, 0)
+  )
+  expect_equal(
+    prob %>%
+      dplyr::filter(is.finite(.time)) %>%
+      dplyr::arrange(.time) %>%
+      dplyr::pull(.pred_survival),
+    exp_prob
+  )
+
+  # all observations with missings
+  lung_pred <- lung[c(14, 14),]
+
+  prob <- survival_prob_coxph(mod, new_data = lung_pred, time = pred_time)
+  prob <- tidyr::unnest(prob, cols = .pred)
+  expect_true(all(is.na(prob$.pred_survival)))
+
+})
+
+test_that("survival_prob_coxph() works with confidence intervals", {
+  mod <- coxph(Surv(time, status) ~ age + ph.ecog, data = lung)
+
+  # time: combination of order, out-of-range, infinite
+  pred_time <- c(-Inf, 0, 100, Inf, 1022, 3000)
+
+  # multiple observations (with 1 missing)
+  lung_pred <- lung[13:15,]
+  surv_fit <- survfit(mod, newdata = lung_pred)
+
+  pred <- survival_prob_coxph(mod, new_data = lung_pred, time = pred_time,
+                              interval = "confidence")
+  exp_pred <- summary(surv_fit, times = pred_time, extend = TRUE)
+
+  pred_na <- pred$.pred[[2]]
+  pred_non_na <- pred$.pred[[3]]
+
+  # get missings right
+  expect_true(all(is.na(pred_na$.pred_lower)))
+  expect_true(all(is.na(pred_na$.pred_upper)))
+  # for non-missings, get interval right
+  expect_equal(
+    pred_non_na$.pred_lower[c(1, 4)],
+    rep(NA_real_, 2)
+  )
+  expect_equal(
+    pred_non_na$.pred_upper[c(1, 4)],
+    rep(NA_real_, 2)
+  )
+  expect_equal(
+    pred_non_na %>%
+      dplyr::filter(is.finite(.time)) %>%
+      dplyr::arrange(.time) %>%
+      dplyr::pull(.pred_lower),
+    exp_pred$lower[,2] # observation in row 15
+  )
+  expect_equal(
+    pred_non_na %>%
+      dplyr::filter(is.finite(.time)) %>%
+      dplyr::arrange(.time) %>%
+      dplyr::pull(.pred_upper),
+    exp_pred$upper[,2] # observation in row 15
+  )
+})
+
+
 # prediction: linear_pred -------------------------------------------------
 
 test_that("linear_pred predictions without strata", {


### PR DESCRIPTION
This is part of #146 

This PR is a follow-up to #216 to now make use of those helper functions for survfit summary objects for proportional hazards models with the `"survival"` and `"glmnet"` engines.

I left all the previous tests on predictions of survival probability untouched to show that they still pass fine. The only change is how the tibbles from `multi_predict()` for glmnet are now arranged: They now are arranged by `penalty` then `.time` instead of the other way around (see example below). I ran a revdepcheck on this and it didn't show any problems.

``` r
library(censored)
#> Loading required package: parsnip
#> Loading required package: survival

f_fit <- suppressWarnings(
  proportional_hazards(penalty = 0.1) %>%
    set_engine("glmnet") %>%
    fit(Surv(time, status) ~ age + ph.ecog, data = lung)
)

pred_penalty <- c(0.1, 0.2)
pred_time <- c(-Inf, 0, 100, Inf, 1022, 3000)

prob <- survival_prob_coxnet(f_fit, new_data = lung[1:3,], time = pred_time, penalty = pred_penalty)
prob$.pred[[1]]
#> # A tibble: 12 × 3
#>    penalty .time .pred_survival
#>      <dbl> <dbl>          <dbl>
#>  1     0.1  -Inf         1     
#>  2     0.1     0         1     
#>  3     0.1   100         0.868 
#>  4     0.1   Inf         0     
#>  5     0.1  1022         0.0476
#>  6     0.1  3000         0.0476
#>  7     0.2  -Inf         1     
#>  8     0.2     0         1     
#>  9     0.2   100         0.868 
#> 10     0.2   Inf         0     
#> 11     0.2  1022         0.0536
#> 12     0.2  3000         0.0536
```

<sup>Created on 2022-10-05 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>



