### PR TITLE
Transform `linear_pred` depending on the distribution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * Added internal `survfit_summary_*()` helper functions (#216).
 
+* Predictions of type `"linear_pred"` for the `"flexsurv"` engine to `survival_reg()` are now on the correct scale for distributions where the natural scale and the unrestricted scale of the location parameter are identical, e.g. `dist = "lnorm"` (#).
+
 
 # censored 0.1.1
 

--- a/R/survival_reg-data.R
+++ b/R/survival_reg-data.R
@@ -281,8 +281,14 @@ make_survival_reg_flexsurv <- function() {
     value = list(
       pre = NULL,
       post = function(results, object) {
+        # flexsurv returns on the natural scale of the location parameter
+        # thus transform to the unrestricted scale before returning
+        location_name <- object$fit$dlist$location
+        location_index <- which(object$fit$dlist$pars == location_name)
+        transformation <- object$fit$dlist$transforms[[location_index]]
+
         results %>%
-          dplyr::mutate(.pred_linear_pred = log(.pred_link)) %>%
+          dplyr::mutate(.pred_linear_pred = transformation(.pred_link)) %>%
           dplyr::select(.pred_linear_pred)
         },
       func = c(fun = "predict"),

--- a/tests/testthat/test-survival_reg-flexsurv.R
+++ b/tests/testthat/test-survival_reg-flexsurv.R
@@ -106,10 +106,25 @@ test_that("linear predictor", {
   )
   exp_pred <- predict(exp_fit, lung[1:5,], type = "linear")
 
+  expect_equal(f_pred$.pred_linear_pred, log(exp_pred$.pred_link))
   expect_s3_class(f_pred, "tbl_df")
   expect_true(all(names(f_pred) == ".pred_linear_pred"))
-  expect_equal(f_pred$.pred_linear_pred, log(exp_pred$.pred_link))
   expect_equal(nrow(f_pred), 5)
+
+
+  f_fit <- survival_reg(dist = "lnorm") %>%
+    set_engine("flexsurv") %>%
+    fit(Surv(time, status) ~ age + sex, data = lung)
+  f_pred <- predict(f_fit, lung[1:5,], type = "linear_pred")
+
+  exp_fit <- flexsurv::flexsurvreg(
+    Surv(time, status) ~ age + sex,
+    data = lung,
+    dist = "lnorm"
+  )
+  exp_pred <- predict(exp_fit, lung[1:5,], type = "linear")
+
+  expect_equal(f_pred$.pred_linear_pred, exp_pred$.pred_link)
 })
 
 


### PR DESCRIPTION
For `flexsurv::flexsurvreg()`, we use predictions of type `"link"` for our prediction type `"linear_pred"`. Those predictions from flexsurv are on the natural scale of the location parameter. censored returns predictions on the unrestricted scale. 

For example, for the `"weibull"` distribution those predictions need to be transformed to the log scale. 
For some other distributions, the natural scale and the unrestricted scale are the same, so no transformation is needed, e.g. `dist = "lnorm"`.

This PR uses the appropriate transformations, already stored in the flexsurv object, instead of always using the log transformation.

https://github.com/tidymodels/censored/pull/213#issuecomment-1300352383