### PR TITLE
Enable `fit_xy()` for `decison_tree()` with the `"rpart"` engine

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,4 +57,4 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Remotes:
-    tidymodels/parsnip#947
+    tidymodels/parsnip

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,7 @@ Suggests:
     ipred,
     partykit,
     pec,
+    prodlim (>= 2023-04-02),
     rmarkdown,
     rpart,
     testthat (>= 3.0.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,7 @@ Suggests:
     ipred,
     partykit,
     pec,
-    prodlim (>= 2023-04-02),
+    prodlim (>= 2023.03.31),
     rmarkdown,
     rpart,
     testthat (>= 3.0.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,4 +56,4 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Remotes:
-    tidymodels/parsnip
+    tidymodels/parsnip#947

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 * Added the new `flexsurvspline` engine for `survival_reg()` (@mattwarkentin, #213).
 
-* The matrix interface for fitting `fit_xy()` now works for censored regression models, with the exception of `decision_tree(engine = "rpart")` (#225, #234).
+* The matrix interface for fitting `fit_xy()` now works for censored regression models (#225, #234, #247).
 
 * Predictions of survival probabilities are now calculated via `summary.survfit()` for `proportional_hazards()` models with the `"survival"` and `"glmnet"` engines, `bag_tree()` models with the `"rpart"` engine, `decision_tree()` models with the `"partykit"` engines, as well as `rand_forest()` models with the `"partykit"` engine (#221, #224). 
 

--- a/tests/testthat/_snaps/decision_tree-rpart.md
+++ b/tests/testthat/_snaps/decision_tree-rpart.md
@@ -1,8 +1,0 @@
-# `fix_xy()` errors
-
-    Code
-      fit_xy(spec, x = lung_x, y = lung_y)
-    Condition
-      Error in `fit_xy()`:
-      ! For the `'rpart'` engine, please use the formula interface via `fit()`.
-

--- a/tests/testthat/test-decision_tree-rpart.R
+++ b/tests/testthat/test-decision_tree-rpart.R
@@ -87,6 +87,8 @@ test_that("survival predictions", {
 # fit via matrix interface ------------------------------------------------
 
 test_that("`fix_xy()` works", {
+  skip_if_not_installed("prodlim", minimum_version = "2023-04-02")
+
   lung_x <- as.matrix(lung[, c("age", "ph.ecog")])
   lung_y <- Surv(lung$time, lung$status)
   lung_pred <- lung[1:5, ]

--- a/tests/testthat/test-decision_tree-rpart.R
+++ b/tests/testthat/test-decision_tree-rpart.R
@@ -86,25 +86,7 @@ test_that("survival predictions", {
 
 # fit via matrix interface ------------------------------------------------
 
-test_that("`fix_xy()` errors", {
-  lung_x <- as.matrix(lung[, c("age", "ph.ecog")])
-  lung_y <- Surv(lung$time, lung$status)
-  lung_pred <- lung[1:5, ]
-
-  spec <- decision_tree() %>%
-    set_engine("rpart") %>%
-    set_mode("censored regression")
-
-  expect_snapshot(error = TRUE, {
-    fit_xy(spec, x = lung_x, y = lung_y)
-  })
-})
-
 test_that("`fix_xy()` works", {
-  skip("until dev version of prodlim is released (current CRAN version: 2019.11.13)")
-  # CRAN prodlim::EventHistory.frame() (called by pec::pecRpart())
-  # can't handle a Surv response which is created outside of the formula
-
   lung_x <- as.matrix(lung[, c("age", "ph.ecog")])
   lung_y <- Surv(lung$time, lung$status)
   lung_pred <- lung[1:5, ]


### PR DESCRIPTION
This is a joint PR with tidymodels/parsnip#947 to enable `fit_xy()` for this particular model/engine.

The stopper was in parsnip and gets removed there. The tests are here and now updated.

What's the recommended way of requiring a specific version of a package which isn't a direct dependency: this needs `prodlim` v2023.03.31 which is a dependency of `riskRegression` which is a dependency of `pec` which is what censored depends on. Should prodlim go into `Suggests`?

closes  #226