### PR TITLE
Fix prediction with glmnet after `fit_xy()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: censored
 Title: 'parsnip' Engines for Survival Models
-Version: 0.1.1.9002
+Version: 0.1.1.9003
 Authors@R: c(
     person("Emil", "Hvitfeldt", , "emil.hvitfeldt@posit.co", role = "aut",
            comment = c(ORCID = "0000-0002-0679-1945")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 * Added the new `flexsurvspline` engine for `survival_reg()` (@mattwarkentin, #213).
 
-* The matrix interface for fitting `fit_xy()` now works for censored regression models (#225, #234, #247).
+* The matrix interface for fitting `fit_xy()` now works for censored regression models (#225, #234, #247, #251).
 
 * Predictions of survival probabilities are now calculated via `summary.survfit()` for `proportional_hazards()` models with the `"survival"` and `"glmnet"` engines, `bag_tree()` models with the `"rpart"` engine, `decision_tree()` models with the `"partykit"` engines, as well as `rand_forest()` models with the `"partykit"` engine (#221, #224). 
 

--- a/R/proportional_hazards.R
+++ b/R/proportional_hazards.R
@@ -44,6 +44,12 @@ fit_xy.proportional_hazards <- function(object,
 
   if (object$engine == "glmnet") {
     # we need to keep the training data for prediction
+    if (!is.matrix(x)) {
+      x <- as.matrix(x)
+    }
+    if (!inherits(y, "Surv")) {
+      y <- y[[1]]
+    }
     res$training_data <- list(x = x, y = y)
   }
 

--- a/R/proportional_hazards.R
+++ b/R/proportional_hazards.R
@@ -45,7 +45,7 @@ fit_xy.proportional_hazards <- function(object,
   if (object$engine == "glmnet") {
     # we need to keep the training data for prediction
     if (!is.matrix(x)) {
-      x <- as.matrix(x)
+      x <- parsnip::maybe_matrix(x)
     }
     if (!inherits(y, "Surv")) {
       y <- y[[1]]

--- a/tests/testthat/test-proportional_hazards-glmnet.R
+++ b/tests/testthat/test-proportional_hazards-glmnet.R
@@ -965,10 +965,46 @@ test_that("predictions with strata and dot in formula", {
 
 # fit via matrix interface ------------------------------------------------
 
-test_that("`fix_xy()` works", {
+test_that("`fix_xy()` works with matrix input", {
   lung2 <- lung[-14, ]
   lung_x <- as.matrix(lung2[, c("age", "ph.ecog")])
   lung_y <- Surv(lung2$time, lung2$status)
+  lung_pred <- lung2[1:5, ]
+
+  spec <- proportional_hazards(penalty = 0.1) %>%
+    set_engine("glmnet")
+  f_fit <- fit(spec, Surv(time, status) ~ age + ph.ecog, data = lung2)
+  xy_fit <- fit_xy(spec, x = lung_x, y = lung_y)
+
+  expect_equal(f_fit$fit$fit, xy_fit$fit$fit)
+
+  f_pred_time <- predict(f_fit, new_data = lung_pred, type = "time")
+  xy_pred_time <- predict(xy_fit, new_data = lung_pred, type = "time")
+  expect_equal(f_pred_time, xy_pred_time)
+
+  f_pred_survival <- predict(
+    f_fit,
+    new_data = lung_pred,
+    type = "survival",
+    eval_time = c(100, 200)
+  )
+  xy_pred_survival <- predict(
+    xy_fit,
+    new_data = lung_pred,
+    type = "survival",
+    eval_time = c(100, 200)
+  )
+  expect_equal(f_pred_survival, xy_pred_survival)
+
+  f_pred_lp <- predict(f_fit, new_data = lung_pred, type = "linear_pred")
+  xy_pred_lp <- predict(xy_fit, new_data = lung_pred, type = "linear_pred")
+  expect_equal(f_pred_lp, xy_pred_lp)
+})
+
+test_that("`fix_xy()` works with data frame input", {
+  lung2 <- lung[-14, ]
+  lung_x <- lung2[, c("age", "ph.ecog")]
+  lung_y <- data.frame(surv = Surv(lung2$time, lung2$status))
   lung_pred <- lung2[1:5, ]
 
   spec <- proportional_hazards(penalty = 0.1) %>%


### PR DESCRIPTION
closes #250

For coxnet models, we need to save the training data to be available at prediction time. We save the inputs to `fit_xy()` in a `fit_xy.proportional_hazards()` method. However, we saved them as-is, it worked for at fit time (since `fit_xy()` can deal with data frame inputs) but failed at prediction time (because `survival_prob_coxnet()` expects the training data as a matrix.

This PR now saves the training data as a matrix (for `x`) and `Surv` object (for `y`) directly in `fit_xy.proportional_hazards()`.

This came up in `tune_grid()`.

``` r
library(censored)
#> Loading required package: parsnip
#> Loading required package: survival

lung2 <- lung[-14, ]
lung_x <- lung2[, c("age", "ph.ecog")]
lung_y <- data.frame(surv = Surv(lung2$time, lung2$status))
lung_pred <- lung2[1:5, ]

spec <- proportional_hazards(penalty = 0.1) %>%
  set_engine("glmnet")
xy_fit <- fit_xy(spec, x = lung_x, y = lung_y)

xy_pred_time <- predict(xy_fit, new_data = lung_pred, type = "time")
```

<sup>Created on 2023-04-06 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>