### PR TITLE
Nest survival/hazard predictions for scalar `eval_time` for flexsurv engines

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 * Improved error messages throughout the package (#248).
 
+* Predictions of survival probability for `survival_reg(engine = "flexsurv")` for a single time point are now nested correctly (#254).
+
 
 # censored 0.1.1
 

--- a/R/survival_reg-data.R
+++ b/R/survival_reg-data.R
@@ -258,12 +258,19 @@ make_survival_reg_flexsurv <- function() {
     value = list(
       pre = NULL,
       post = function(pred, object) {
-        pred %>%
-          dplyr::rowwise() %>%
-          dplyr::mutate(
-            .pred = list(dplyr::rename(.pred, .eval_time = .time))
-          ) %>%
-          dplyr::ungroup()
+        if (".pred" %in% names(pred)) {
+          pred %>%
+            dplyr::rowwise() %>%
+            dplyr::mutate(
+              .pred = list(dplyr::rename(.pred, .eval_time = .time))
+            ) %>%
+            dplyr::ungroup()
+        } else {
+          dplyr::rename(pred, .eval_time = .time) %>%
+            dplyr::mutate(.row = seq_len(nrow(pred))) %>%
+            tidyr::nest(.by = .row) %>%
+            dplyr::select(-.row)
+        }
       },
       func = c(fun = "predict"),
       args =
@@ -284,12 +291,19 @@ make_survival_reg_flexsurv <- function() {
     value = list(
       pre = NULL,
       post = function(pred, object) {
-        pred %>%
-          dplyr::rowwise() %>%
-          dplyr::mutate(
-            .pred = list(dplyr::rename(.pred, .eval_time = .time))
-          ) %>%
-          dplyr::ungroup()
+        if (".pred" %in% names(pred)) {
+          pred %>%
+            dplyr::rowwise() %>%
+            dplyr::mutate(
+              .pred = list(dplyr::rename(.pred, .eval_time = .time))
+            ) %>%
+            dplyr::ungroup()
+        } else {
+          dplyr::rename(pred, .eval_time = .time) %>%
+            dplyr::mutate(.row = seq_len(nrow(pred))) %>%
+            tidyr::nest(.by = .row) %>%
+            dplyr::select(-.row)
+        }
       },
       func = c(fun = "predict"),
       args =
@@ -429,12 +443,19 @@ make_survival_reg_flexsurvspline <- function() {
     value = list(
       pre = NULL,
       post = function(pred, object) {
-        pred %>%
-          dplyr::rowwise() %>%
-          dplyr::mutate(
-            .pred = list(dplyr::rename(.pred, .eval_time = .time))
-          ) %>%
-          dplyr::ungroup()
+        if (".pred" %in% names(pred)) {
+          pred %>%
+            dplyr::rowwise() %>%
+            dplyr::mutate(
+              .pred = list(dplyr::rename(.pred, .eval_time = .time))
+            ) %>%
+            dplyr::ungroup()
+        } else {
+          dplyr::rename(pred, .eval_time = .time) %>%
+            dplyr::mutate(.row = seq_len(nrow(pred))) %>%
+            tidyr::nest(.by = .row) %>%
+            dplyr::select(-.row)
+        }
       },
       func = c(fun = "predict"),
       args =
@@ -455,12 +476,19 @@ make_survival_reg_flexsurvspline <- function() {
     value = list(
       pre = NULL,
       post = function(pred, object) {
-        pred %>%
-          dplyr::rowwise() %>%
-          dplyr::mutate(
-            .pred = list(dplyr::rename(.pred, .eval_time = .time))
-          ) %>%
-          dplyr::ungroup()
+        if (".pred" %in% names(pred)) {
+          pred %>%
+            dplyr::rowwise() %>%
+            dplyr::mutate(
+              .pred = list(dplyr::rename(.pred, .eval_time = .time))
+            ) %>%
+            dplyr::ungroup()
+        } else {
+          dplyr::rename(pred, .eval_time = .time) %>%
+            dplyr::mutate(.row = seq_len(nrow(pred))) %>%
+            tidyr::nest(.by = .row) %>%
+            dplyr::select(-.row)
+        }
       },
       func = c(fun = "predict"),
       args =

--- a/tests/testthat/test-survival_reg-flexsurv.R
+++ b/tests/testthat/test-survival_reg-flexsurv.R
@@ -112,6 +112,25 @@ test_that("survival probability prediction", {
   )
 })
 
+test_that("survival probabilities for single eval time point", {
+  f_fit <- survival_reg(engine = "flexsurv") %>%
+    fit(Surv(time, status) ~ age + sex, data = lung)
+
+  pred <- predict(f_fit, lung[1:3, ], type = "survival", eval_time = 100)
+
+  expect_identical(nrow(pred), 3L)
+  expect_identical(names(pred), ".pred")
+  expect_true(
+    all(purrr::map_lgl(
+      pred$.pred,
+      ~ all(names(.x) == c(
+        ".eval_time",
+        ".pred_survival"
+      ))
+    ))
+  )
+})
+
 # prediction: linear_pred -------------------------------------------------
 
 test_that("linear predictor", {
@@ -253,6 +272,25 @@ test_that("hazard prediction", {
     f_pred$.pred[[1]]$.pred_hazard,
     rms_haz,
     tolerance = 0.001
+  )
+})
+
+test_that("hazard for single eval time point", {
+  f_fit <- survival_reg(engine = "flexsurv") %>%
+    fit(Surv(time, status) ~ age + sex, data = lung)
+
+  pred <- predict(f_fit, lung[1:3, ], type = "hazard", eval_time = 100)
+
+  expect_identical(nrow(pred), 3L)
+  expect_identical(names(pred), ".pred")
+  expect_true(
+    all(purrr::map_lgl(
+      pred$.pred,
+      ~ all(names(.x) == c(
+        ".eval_time",
+        ".pred_hazard"
+      ))
+    ))
   )
 })
 

--- a/tests/testthat/test-survival_reg-flexsurvspline.R
+++ b/tests/testthat/test-survival_reg-flexsurvspline.R
@@ -116,6 +116,25 @@ test_that("survival probability prediction", {
   )
 })
 
+test_that("survival probabilities for single eval time point", {
+  f_fit <- survival_reg(engine = "flexsurvspline") %>%
+    fit(Surv(time, status) ~ age + sex, data = lung)
+
+  pred <- predict(f_fit, lung[1:3, ], type = "survival", eval_time = 100)
+
+  expect_identical(nrow(pred), 3L)
+  expect_identical(names(pred), ".pred")
+  expect_true(
+    all(purrr::map_lgl(
+      pred$.pred,
+      ~ all(names(.x) == c(
+        ".eval_time",
+        ".pred_survival"
+      ))
+    ))
+  )
+})
+
 # prediction: linear_pred -------------------------------------------------
 
 test_that("linear predictor", {
@@ -255,6 +274,26 @@ test_that("hazard prediction", {
   )
   expect_equal(f_pred, exp_pred)
 })
+
+test_that("hazard for single eval time point", {
+  f_fit <- survival_reg(engine = "flexsurvspline") %>%
+    fit(Surv(time, status) ~ age + sex, data = lung)
+
+  pred <- predict(f_fit, lung[1:3, ], type = "hazard", eval_time = 100)
+
+  expect_identical(nrow(pred), 3L)
+  expect_identical(names(pred), ".pred")
+  expect_true(
+    all(purrr::map_lgl(
+      pred$.pred,
+      ~ all(names(.x) == c(
+        ".eval_time",
+        ".pred_hazard"
+      ))
+    ))
+  )
+})
+
 
 # fit via matrix interface ------------------------------------------------
 


### PR DESCRIPTION
Before:

``` r
library(censored)
#> Loading required package: parsnip
#> Loading required package: survival

survival_reg(engine = "flexsurv") %>%
  fit(Surv(time, status) ~ age + sex, data = lung) %>%
  predict(lung[1:3, ], type = "survival", time = 100) 
#> [snip: parsnip warning on `time` arg]
#> # A tibble: 3 × 2
#>   .time .pred_survival
#>   <dbl>          <dbl>
#> 1   100          0.803
#> 2   100          0.820
#> 3   100          0.849
```

<sup>Created on 2023-04-11 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

After:
``` r
library(censored)
#> Loading required package: parsnip
#> Loading required package: survival

survival_reg(engine = "flexsurv") %>%
  fit(Surv(time, status) ~ age + sex, data = lung) %>%
  predict(lung[1:3, ], type = "survival", eval_time = 100) 
#> # A tibble: 3 × 1
#>   .pred           
#>   <list>          
#> 1 <tibble [1 × 2]>
#> 2 <tibble [1 × 2]>
#> 3 <tibble [1 × 2]>
```

<sup>Created on 2023-04-11 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>