### PR TITLE
fix pred survival for single obs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 
 * Predictions of survival probability for `survival_reg(engine = "flexsurv")` for a single time point are now nested correctly (#254).
 
+* Predictions of survival probability for `decision_tree(engine = "rpart")` for a single observation now work (#256).
+
 
 # censored 0.1.1
 

--- a/R/decision_tree-data.R
+++ b/R/decision_tree-data.R
@@ -74,6 +74,9 @@ make_decision_tree_rpart <- function() {
       pre = NULL,
       post = function(x, object) {
         eval_time <- object$spec$method$pred$survival$args$eval_time
+        if (!is.matrix(x)) {
+          x <- matrix(x, nrow = 1)
+        }
         matrix_to_nested_tibbles_survival(x, eval_time)
       },
       func = c(pkg = "pec", fun = "predictSurvProb"),

--- a/tests/testthat/test-decision_tree-rpart.R
+++ b/tests/testthat/test-decision_tree-rpart.R
@@ -37,6 +37,10 @@ test_that("time predictions", {
   expect_true(all(names(f_pred) == ".pred_time"))
   expect_equal(f_pred$.pred_time, unname(exp_f_pred))
   expect_equal(nrow(f_pred), nrow(lung))
+
+  # single observation
+  f_pred <- predict(f_fit, lung[2,], type = "time")
+  expect_identical(nrow(f_pred), 1L)
 })
 
 
@@ -81,6 +85,14 @@ test_that("survival predictions", {
     tidyr::unnest(f_pred, cols = c(.pred))$.pred_survival,
     as.numeric(t(exp_f_pred))
   )
+
+  # single observation
+  f_pred <- predict(f_fit, lung[2,], type = "survival", eval_time = 100:200)
+  expect_identical(nrow(f_pred), 1L)
+  expect_true(
+    all(purrr::map_lgl(f_pred$.pred, ~ all(names(.x) == c(".eval_time", ".pred_survival"))))
+  )
+  expect_equal(f_pred$.pred[[1]]$.eval_time, 100:200)
 })
 
 


### PR DESCRIPTION
closes #255

``` r
library(censored)
#> Loading required package: parsnip
#> Loading required package: survival

decision_tree(engine = "rpart") %>%
  set_mode("censored regression") %>%
  fit(Surv(time, status) ~ ., data = lung) %>%
  predict(lung[2,], type = "survival", eval_time = c(100, 200))
#> # A tibble: 1 × 1
#>                .pred
#>   <list<tibble[,2]>>
#> 1            [2 × 2]
```

<sup>Created on 2023-04-11 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>