### PR TITLE
Prediction of single observation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@
 
 * Predictions of survival probability for `decision_tree(engine = "rpart")` for a single observation now work (#256).
 
+* Predictions of `type = "quantile"` for `survival_reg(engine = "survival")` for a single observation now work (#257).
+
 
 # censored 0.1.1
 

--- a/R/survival_reg-survival.R
+++ b/R/survival_reg-survival.R
@@ -3,6 +3,10 @@
 # ------------------------------------------------------------------------------
 
 survreg_quant <- function(results, object) {
+  if (!is.matrix(results)) {
+    results <- matrix(results, nrow = 1)
+  }
+
   pctl <- object$spec$method$pred$quantile$args$p
   n <- nrow(results)
   p <- ncol(results)

--- a/tests/testthat/test-bag_tree-rpart.R
+++ b/tests/testthat/test-bag_tree-rpart.R
@@ -36,6 +36,10 @@ test_that("time predictions", {
     purrr::map_dbl(exp_f_pred, ~ quantile(.x, probs = .5)$quantile)
   )
   expect_equal(nrow(f_pred), nrow(lung))
+
+  # single observation
+  f_pred_1 <- predict(f_fit, lung[1, ], type = "time")
+  expect_identical(nrow(f_pred_1), 1L)
 })
 
 test_that("time predictions without surrogate splits for NA", {

--- a/tests/testthat/test-boost_tree-mboost.R
+++ b/tests/testthat/test-boost_tree-mboost.R
@@ -217,9 +217,11 @@ test_that("linear_pred predictions", {
   expect_true(all(names(f_pred) == ".pred_linear_pred"))
   expect_equal(f_pred$.pred_linear_pred, as.vector(exp_f_pred))
   expect_equal(nrow(f_pred), nrow(lung2))
+
+  # single observation
+  f_pred_1 <- predict(f_fit, lung2[1, ], type = "linear_pred")
+  expect_identical(nrow(f_pred_1), 1L)
 })
-
-
 
 
 # fit via matrix interface ------------------------------------------------

--- a/tests/testthat/test-decision_tree-partykit.R
+++ b/tests/testthat/test-decision_tree-partykit.R
@@ -47,6 +47,10 @@ test_that("time predictions", {
   expect_true(all(names(f_pred) == ".pred_time"))
   expect_equal(f_pred$.pred_time, unname(exp_f_pred))
   expect_equal(nrow(f_pred), nrow(lung))
+
+  # single observation
+  f_pred_1 <- predict(f_fit, lung[1, ], type = "time")
+  expect_identical(nrow(f_pred_1), 1L)
 })
 
 
@@ -89,6 +93,7 @@ test_that("survival predictions", {
     rep(100:200, nrow(lung))
   )
 
+  # single observation
   f_pred <- predict(f_fit, lung[1, ], type = "survival", eval_time = 306)
   new_km <- predict(exp_f_fit, newdata = lung[1, ], type = "prob")[[1]]
   # Prediction should be fairly near the actual value

--- a/tests/testthat/test-decision_tree-rpart.R
+++ b/tests/testthat/test-decision_tree-rpart.R
@@ -39,8 +39,8 @@ test_that("time predictions", {
   expect_equal(nrow(f_pred), nrow(lung))
 
   # single observation
-  f_pred <- predict(f_fit, lung[2,], type = "time")
-  expect_identical(nrow(f_pred), 1L)
+  f_pred_1 <- predict(f_fit, lung[2,], type = "time")
+  expect_identical(nrow(f_pred_1), 1L)
 })
 
 

--- a/tests/testthat/test-rand_forest-partykit.R
+++ b/tests/testthat/test-rand_forest-partykit.R
@@ -58,6 +58,10 @@ test_that("time predictions", {
   expect_true(all(names(f_pred) == ".pred_time"))
   expect_equal(f_pred$.pred_time, unname(exp_f_pred))
   expect_equal(nrow(f_pred), nrow(lung))
+
+  # single observation
+  f_pred_1 <- predict(f_fit, lung[2,], type = "time")
+  expect_identical(nrow(f_pred_1), 1L)
 })
 
 

--- a/tests/testthat/test-survival_reg-flexsurv.R
+++ b/tests/testthat/test-survival_reg-flexsurv.R
@@ -42,6 +42,10 @@ test_that("flexsurv time prediction", {
   f_pred <- predict(f_fit, head(lung), type = "time")
 
   expect_equal(f_pred, exp_pred)
+
+  # single observation
+  f_pred_1 <- predict(f_fit, lung[2,], type = "time")
+  expect_identical(nrow(f_pred_1), 1L)
 })
 
 
@@ -110,6 +114,10 @@ test_that("survival probability prediction", {
       ))
     ))
   )
+
+  # single observation
+  f_pred_1 <- predict(f_fit, lung[2,], type = "survival", eval_time = 100)
+  expect_identical(nrow(f_pred_1), 1L)
 })
 
 test_that("survival probabilities for single eval time point", {
@@ -165,6 +173,10 @@ test_that("linear predictor", {
   exp_pred <- predict(exp_fit, lung[1:5, ], type = "linear")
 
   expect_equal(f_pred$.pred_linear_pred, exp_pred$.pred_link)
+
+  # single observation
+  f_pred_1 <- predict(f_fit, lung[2,], type = "linear_pred")
+  expect_identical(nrow(f_pred_1), 1L)
 })
 
 
@@ -227,6 +239,10 @@ test_that("quantile predictions", {
       ))
     ))
   )
+
+  # single observation
+  f_pred_1 <- predict(fit_s, bladder[2,], type = "quantile")
+  expect_identical(nrow(f_pred_1), 1L)
 })
 
 # prediction: hazard ------------------------------------------------------
@@ -273,6 +289,10 @@ test_that("hazard prediction", {
     rms_haz,
     tolerance = 0.001
   )
+
+  # single observation
+  f_pred_1 <- predict(f_fit, lung[2,], type = "hazard", eval_time = c(100, 200))
+  expect_identical(nrow(f_pred_1), 1L)
 })
 
 test_that("hazard for single eval time point", {

--- a/tests/testthat/test-survival_reg-flexsurvspline.R
+++ b/tests/testthat/test-survival_reg-flexsurvspline.R
@@ -37,6 +37,10 @@ test_that("time prediction", {
   f_pred <- predict(f_fit, head(lung), type = "time")
 
   expect_equal(f_pred, exp_pred)
+
+  # single observation
+  f_pred_1 <- predict(f_fit, lung[2,], type = "time")
+  expect_identical(nrow(f_pred_1), 1L)
 })
 
 # prediction: survival ----------------------------------------------------
@@ -114,6 +118,10 @@ test_that("survival probability prediction", {
       ))
     ))
   )
+
+  # single observation
+  f_pred_1 <- predict(f_fit, lung[2,], type = "survival", eval_time = 100)
+  expect_identical(nrow(f_pred_1), 1L)
 })
 
 test_that("survival probabilities for single eval time point", {
@@ -154,6 +162,10 @@ test_that("linear predictor", {
   expect_s3_class(f_pred, "tbl_df")
   expect_true(all(names(f_pred) == ".pred_linear_pred"))
   expect_equal(nrow(f_pred), 5)
+
+  # single observation
+  f_pred_1 <- predict(f_fit, lung[2,], type = "linear_pred")
+  expect_identical(nrow(f_pred_1), 1L)
 })
 
 # prediction: quantile ----------------------------------------------------
@@ -218,6 +230,10 @@ test_that("quantile predictions", {
       ))
     ))
   )
+
+  # single observation
+  f_pred_1 <- predict(fit_s, bladder[2,], type = "quantile")
+  expect_identical(nrow(f_pred_1), 1L)
 })
 
 # prediction: hazard ------------------------------------------------------
@@ -273,6 +289,10 @@ test_that("hazard prediction", {
     )
   )
   expect_equal(f_pred, exp_pred)
+
+  # single observation
+  f_pred_1 <- predict(f_fit, lung[2,], type = "hazard", eval_time = c(100, 200))
+  expect_identical(nrow(f_pred_1), 1L)
 })
 
 test_that("hazard for single eval time point", {

--- a/tests/testthat/test-survival_reg-survival.R
+++ b/tests/testthat/test-survival_reg-survival.R
@@ -36,6 +36,10 @@ test_that("survival time prediction", {
   exp_pred <- predict(res$fit, head(lung))
   exp_pred <- tibble::tibble(.pred_time = unname(exp_pred))
   expect_equal(exp_pred, predict(res, head(lung)))
+
+  # single observation
+  f_pred_1 <- predict(res, lung[1, ], type = "time")
+  expect_identical(nrow(f_pred_1), 1L)
 })
 
 # prediction: survival ----------------------------------------------------
@@ -65,6 +69,10 @@ test_that("survival probability prediction", {
     rms_surv,
     tolerance = 0.001
   )
+
+  # single observation
+  f_pred_1 <- predict(res, lung[1, ], type = "survival", eval_time = c(100, 500))
+  expect_identical(nrow(f_pred_1), 1L)
 })
 
 
@@ -83,6 +91,10 @@ test_that("linear predictor", {
   expect_true(all(names(f_pred) == ".pred_linear_pred"))
   expect_equal(f_pred$.pred_linear_pred, unname(exp_pred))
   expect_equal(nrow(f_pred), 5)
+
+  # single observation
+  f_pred_1 <- predict(f_fit, lung[1, ], type = "linear_pred")
+  expect_identical(nrow(f_pred_1), 1L)
 })
 
 
@@ -101,6 +113,10 @@ test_that("prediction of survival time quantile", {
   obs_quant <- predict(res, head(lung), type = "quantile", quantile = (2:4) / 5)
 
   expect_equal(as.data.frame(exp_quant), as.data.frame(obs_quant))
+
+  # single observation
+  f_pred_1 <- predict(res, lung[1, ], type = "quantile")
+  expect_identical(nrow(f_pred_1), 1L)
 })
 
 
@@ -131,6 +147,10 @@ test_that("survival hazard prediction", {
     rms_haz[-1],
     tolerance = 0.001
   )
+
+  # single observation
+  f_pred_1 <- predict(res, lung[1, ], type = "hazard", eval_time = c(100, 500))
+  expect_identical(nrow(f_pred_1), 1L)
 })
 
 # fit via matrix interface ------------------------------------------------


### PR DESCRIPTION
This PR add tests on prediction of a single observation and fixes the now surfaced bug for predictions of `type = "quantile"` for `survival_reg(engine = "survival")`.