### PR TITLE
Save training data as used in `coxnet_train()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # censored (development version)
 
+* Fixed a bug for `proportional_hazards(engine = "glmnet")` where prediction didn't work for a `workflow()` with a formula as the preprocessor (#264).
+
+
 # censored 0.2.0
 
 ## Cross-package changes with parsnip

--- a/R/proportional_hazards.R
+++ b/R/proportional_hazards.R
@@ -44,13 +44,9 @@ fit_xy.proportional_hazards <- function(object,
 
   if (object$engine == "glmnet") {
     # we need to keep the training data for prediction
-    if (!is.matrix(x)) {
-      x <- parsnip::maybe_matrix(x)
-    }
-    if (!inherits(y, "Surv")) {
-      y <- y[[1]]
-    }
-    res$training_data <- list(x = x, y = y)
+    # res$fit$preproc carries it as used inside of `coxnet_train()`
+    training_data_ind <- names(res$fit$preproc) %in% c("x", "y")
+    res$training_data <- res$fit$preproc[training_data_ind]
   }
 
   res


### PR DESCRIPTION
Closes #263

It's `survival_time_coxnet()` which breaks because the training data `object$training_data$x` carries an intercept column when going into `survival::survfit()`.

This happens because `fit.workflow()` creates a mold that includes the intercept because the [encoding in censored](https://github.com/tidymodels/censored/blob/f8d2dc1eb15893a8f3c29aa5770035d5be71e22a/R/proportional_hazards-data.R#L132) says `compute_intercept = TRUE`.

That intercept column is still part of `x` when it reaches `fit_xy.proportional_hazards()` where it gets written into the `object$training_data$x` mentioned earlier.

The intercept column does not make it to the actual call to glmnet (so no bug when fitting) because we set `remove_intercept = TRUE` in the encodings which gets picked up in `xy_form()` which passes it to `.convert_xy_to_form_fit()` and the column is removed.

That means everything is okay here inside of `censored::coxnet_train()` and inside of `fit_xy.proportional_hazards()` we should take the training data as returned from `coxnet_train()`, like we do in `fit.proportional_hazards()`.

``` r
library(tidymodels)
library(prodlim)
library(censored)
#> Loading required package: survival

set.seed(1)
sim_tr <- SimSurv(500) %>%
  mutate(event_time = Surv(time, event)) %>%
  select(event_time, X1, X2)
new_x <- sim_tr[1:5, 2:3]

glmn_spec <-
  proportional_hazards(penalty = .01) %>%
  set_engine("glmnet")

glmn_wflow <-
  workflow() %>%
  add_model(glmn_spec) %>%
  add_formula(event_time ~ X1 + X2)

glmn_wflow_fit <- fit(glmn_wflow, data = sim_tr)

predict(glmn_wflow_fit, new_data = new_x)
#> # A tibble: 5 × 1
#>   .pred_time
#>        <dbl>
#> 1       7.25
#> 2       5.00
#> 3      11.9 
#> 4       2.69
#> 5       7.63
```

<sup>Created on 2023-04-26 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>