### PR TITLE
Clean-up of `$fit` slot of fitted glmnet models

### DIFF
--- a/R/proportional_hazards-data.R
+++ b/R/proportional_hazards-data.R
@@ -184,7 +184,7 @@ make_proportional_hazards_glmnet <- function() {
       func = c(fun = "predict"),
       args =
         list(
-          object = expr(object$fit$fit),
+          object = expr(object$fit),
           newx = expr(new_data),
           type = "link",
           s = expr(object$spec$args$penalty)
@@ -240,7 +240,7 @@ make_proportional_hazards_glmnet <- function() {
       func = c(fun = "predict"),
       args =
         list(
-          object = expr(object$fit$fit),
+          object = expr(object$fit),
           newx = expr(new_data)
         )
     )

--- a/R/proportional_hazards-glmnet.R
+++ b/R/proportional_hazards-glmnet.R
@@ -193,10 +193,10 @@ print._coxnet <- function(x, ...) {
   cat("parsnip model object\n\n")
   cat("Fit time: ", prettyunits::pretty_sec(x$elapsed[["elapsed"]]), "\n")
 
-  if (inherits(x$fit$fit, "try-error")) {
+  if (inherits(x$fit, "try-error")) {
     cat("Model fit failed with error:\n", x$fit, "\n")
   } else {
-    print(x$fit$fit, ...)
+    print(x$fit, ...)
     cat("The training data has been saved for prediction.\n")
   }
   invisible(x)
@@ -438,7 +438,7 @@ survival_time_coxnet <- function(object, new_data, penalty = NULL, ...) {
   }
 
   y <- survival::survfit(
-    object$fit$fit,
+    object$fit,
     newx = new_x,
     newstrata = new_strata,
     s = penalty,
@@ -546,7 +546,7 @@ survival_prob_coxnet <- function(object,
   }
 
   y <- survival::survfit(
-    object$fit$fit,
+    object$fit,
     newx = new_x,
     newstrata = new_strata,
     s = penalty,

--- a/R/proportional_hazards.R
+++ b/R/proportional_hazards.R
@@ -20,6 +20,7 @@ fit.proportional_hazards <- function(object,
     # is set up: parsnip::prepare_data() would automatically run with the
     # modified terms in $preproc$terms which are missing the strata term
     res$preproc$coxnet <- res$fit$preproc[!training_data_ind]
+    res$fit <- res$fit$fit
     res$formula <- formula
   }
 
@@ -47,6 +48,7 @@ fit_xy.proportional_hazards <- function(object,
     # res$fit$preproc carries it as used inside of `coxnet_train()`
     training_data_ind <- names(res$fit$preproc) %in% c("x", "y")
     res$training_data <- res$fit$preproc[training_data_ind]
+    res$fit <- res$fit$fit
   }
 
   res

--- a/tests/testthat/test-proportional_hazards-glmnet.R
+++ b/tests/testthat/test-proportional_hazards-glmnet.R
@@ -17,7 +17,7 @@ test_that("model object", {
   )
 
   # Removing call element
-  expect_equal(f_fit$fit$fit[-11], exp_f_fit[-11])
+  expect_equal(f_fit$fit[-11], exp_f_fit[-11])
 })
 
 test_that("print coxnet model", {
@@ -992,7 +992,7 @@ test_that("`fix_xy()` works with matrix input", {
   f_fit <- fit(spec, Surv(time, status) ~ age + ph.ecog, data = lung2)
   xy_fit <- fit_xy(spec, x = lung_x, y = lung_y)
 
-  expect_equal(f_fit$fit$fit, xy_fit$fit$fit)
+  expect_equal(f_fit$fit, xy_fit$fit)
 
   f_pred_time <- predict(f_fit, new_data = lung_pred, type = "time")
   xy_pred_time <- predict(xy_fit, new_data = lung_pred, type = "time")


### PR DESCRIPTION
closes #265

But: the size of the total object is now bigger?? 🤔 

To compare from the issue/`main`: 
```
lobstr::obj_size(glmn_fit)
#> 112.16 kB
```

``` r
library(censored)
#> Loading required package: parsnip
#> Loading required package: survival
lung2 <- lung[-14, ]

glmn_fit <- proportional_hazards(penalty = 0.1) %>%
  set_engine("glmnet") %>%
  fit(Surv(time, status) ~ age + ph.ecog, data = lung2)

lobstr::obj_size(lung2)
#> 34.61 kB
lobstr::obj_size(glmn_fit)
#> 172.58 kB
lobstr::obj_size(glmn_fit$fit)
#> 9.54 kB
lobstr::obj_size(glmn_fit$fit$fit)
#> 0 B
```

<sup>Created on 2023-04-26 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>