### PR TITLE
set mode in set_dependency()

### DIFF
--- a/R/decision_tree-data.R
+++ b/R/decision_tree-data.R
@@ -92,8 +92,18 @@ make_decision_tree_rpart <- function() {
 
 make_decision_tree_partykit <- function() {
   parsnip::set_model_engine("decision_tree", mode = "censored regression", eng = "partykit")
-  parsnip::set_dependency("decision_tree", eng = "partykit", pkg = "partykit")
-  parsnip::set_dependency("decision_tree", eng = "partykit", pkg = "censored", mode = "censored regression")
+  parsnip::set_dependency(
+    "decision_tree", 
+    eng = "partykit", 
+    pkg = "partykit", 
+    mode = "censored regression"
+  )
+  parsnip::set_dependency(
+    "decision_tree", 
+    eng = "partykit", 
+    pkg = "censored", 
+    mode = "censored regression"
+  )
 
   parsnip::set_model_arg(
     model = "decision_tree",

--- a/R/decision_tree-data.R
+++ b/R/decision_tree-data.R
@@ -93,7 +93,7 @@ make_decision_tree_rpart <- function() {
 make_decision_tree_partykit <- function() {
   parsnip::set_model_engine("decision_tree", mode = "censored regression", eng = "partykit")
   parsnip::set_dependency("decision_tree", eng = "partykit", pkg = "partykit")
-  parsnip::set_dependency("decision_tree", eng = "partykit", pkg = "censored")
+  parsnip::set_dependency("decision_tree", eng = "partykit", pkg = "censored", mode = "censored regression")
 
   parsnip::set_model_arg(
     model = "decision_tree",


### PR DESCRIPTION
bug fix for https://github.com/tidymodels/tidymodels.org/pull/45.

This caused the partykit classification model to think it needed censored

``` r
library(parsnip)
library(bonsai)
library(censored)

parsnip::get_model_env()$decision_tree_pkgs |>
  dplyr::filter(engine == "partykit", mode == "classification") |>
  dplyr::pull(pkg)
#> [[1]]
#> [1] "partykit" "bonsai"   "censored"
```