### PR TITLE
Test predicting for out-of-domain time points

### DIFF
--- a/tests/testthat/test-bag_tree-rpart.R
+++ b/tests/testthat/test-bag_tree-rpart.R
@@ -205,6 +205,19 @@ test_that("survival predictions without surrogate splits for NA", {
   expect_true(!any(is.na(f_pred$.pred[[3]]$.pred_survival)))
 })
 
+test_that("can predict for out-of-domain timepoints", {
+  eval_time_obs_max_and_ood <- c(1022, 2000)
+  obs_without_NA <- lung[2,]
+
+  mod <- bag_tree() %>%
+    set_mode("censored regression") %>%
+    set_engine("rpart") %>%
+    fit(Surv(time, status) ~ ., data = lung)
+
+  expect_no_error(
+    preds <- predict(mod, obs_without_NA, type = "survival", eval_time = eval_time_obs_max_and_ood)
+  )
+})
 
 # fit via matrix interface ------------------------------------------------
 

--- a/tests/testthat/test-boost_tree-mboost.R
+++ b/tests/testthat/test-boost_tree-mboost.R
@@ -101,7 +101,6 @@ test_that("survival predictions", {
   )
 })
 
-
 test_that("survival_curve_to_prob() works", {
   lung_pred <- tidyr::drop_na(lung)
 
@@ -185,6 +184,20 @@ test_that("survival_prob_mboost() works", {
   #   eval_time = c(0, 100, 200)
   # )
   # expect_equal(nrow(pred), 1)
+})
+
+test_that("can predict for out-of-domain timepoints", {
+  eval_time_obs_max_and_ood <- c(1022, 2000)
+  obs_without_NA <- lung[c(2,4),] # two observations because of https://github.com/boost-R/mboost/issues/117
+
+  mod <- boost_tree() %>%
+    set_mode("censored regression") %>%
+    set_engine("mboost") %>%
+    fit(Surv(time, status) ~ ., data = lung)
+
+  expect_no_error(
+    preds <- predict(mod, obs_without_NA, type = "survival", eval_time = eval_time_obs_max_and_ood)
+  )
 })
 
 # prediction: linear_pred -------------------------------------------------

--- a/tests/testthat/test-decision_tree-partykit.R
+++ b/tests/testthat/test-decision_tree-partykit.R
@@ -105,6 +105,19 @@ test_that("survival predictions", {
   )
 })
 
+test_that("can predict for out-of-domain timepoints", {
+  eval_time_obs_max_and_ood <- c(1022, 2000)
+  obs_without_NA <- lung[2,]
+
+  mod <- decision_tree() %>%
+    set_mode("censored regression") %>%
+    set_engine("partykit") %>%
+    fit(Surv(time, status) ~ ., data = lung)
+
+  expect_no_error(
+    preds <- predict(mod, obs_without_NA, type = "survival", eval_time = eval_time_obs_max_and_ood)
+  )
+})
 
 # fit via matrix interface ------------------------------------------------
 

--- a/tests/testthat/test-decision_tree-rpart.R
+++ b/tests/testthat/test-decision_tree-rpart.R
@@ -95,6 +95,19 @@ test_that("survival predictions", {
   expect_equal(f_pred$.pred[[1]]$.eval_time, 100:200)
 })
 
+test_that("can predict for out-of-domain timepoints", {
+  eval_time_obs_max_and_ood <- c(1022, 2000)
+  obs_without_NA <- lung[2,]
+
+  mod <- decision_tree() %>%
+    set_mode("censored regression") %>%
+    set_engine("rpart") %>%
+    fit(Surv(time, status) ~ ., data = lung)
+
+  expect_no_error(
+    preds <- predict(mod, obs_without_NA, type = "survival", eval_time = eval_time_obs_max_and_ood)
+  )
+})
 
 # fit via matrix interface ------------------------------------------------
 

--- a/tests/testthat/test-proportional_hazards-glmnet.R
+++ b/tests/testthat/test-proportional_hazards-glmnet.R
@@ -717,6 +717,20 @@ test_that("survival_prob_coxnet() works for multiple penalty values", {
   expect_true(all(is.na(prob$.pred_survival)))
 })
 
+test_that("can predict for out-of-domain timepoints", {
+  eval_time_obs_max_and_ood <- c(1022, 2000)
+  obs_without_NA <- lung[2,]
+
+  mod <- proportional_hazards(penalty = 0.1) %>%
+    set_mode("censored regression") %>%
+    set_engine("glmnet") %>%
+    fit(Surv(time, status) ~ ., data = lung)
+
+  expect_no_error(
+    preds <- predict(mod, obs_without_NA, type = "survival", eval_time = eval_time_obs_max_and_ood)
+  )
+})
+
 # prediction: linear_pred -------------------------------------------------
 
 test_that("linear_pred predictions without strata", {

--- a/tests/testthat/test-proportional_hazards-survival.R
+++ b/tests/testthat/test-proportional_hazards-survival.R
@@ -449,6 +449,19 @@ test_that("survival_prob_coxph() works with confidence intervals", {
   )
 })
 
+test_that("can predict for out-of-domain timepoints", {
+  eval_time_obs_max_and_ood <- c(1022, 2000)
+  obs_without_NA <- lung[2,]
+
+  mod <- proportional_hazards() %>%
+    set_mode("censored regression") %>%
+    set_engine("survival") %>%
+    fit(Surv(time, status) ~ ., data = lung)
+
+  expect_no_error(
+    preds <- predict(mod, obs_without_NA, type = "survival", eval_time = eval_time_obs_max_and_ood)
+  )
+})
 
 # prediction: linear_pred -------------------------------------------------
 

--- a/tests/testthat/test-rand_forest-aorsf.R
+++ b/tests/testthat/test-rand_forest-aorsf.R
@@ -29,7 +29,6 @@ test_that("model object", {
   )
 })
 
-
 # prediction: survival ----------------------------------------------------
 
 test_that("survival predictions", {
@@ -160,6 +159,20 @@ test_that("survival predictions", {
   )
 })
 
+test_that("can predict for out-of-domain timepoints", {
+  eval_time_obs_max_and_ood <- c(1022, 2000)
+  obs_without_NA <- lung[2,]
+  lung_orsf <- na.omit(lung)
+
+  mod <- rand_forest() %>%
+    set_mode("censored regression") %>%
+    set_engine("aorsf") %>%
+    fit(Surv(time, status) ~ ., data = lung_orsf)
+
+  expect_no_error(
+    preds <- predict(mod, obs_without_NA, type = "survival", eval_time = eval_time_obs_max_and_ood)
+  )
+})
 
 # fit via matrix interface ------------------------------------------------
 

--- a/tests/testthat/test-rand_forest-partykit.R
+++ b/tests/testthat/test-rand_forest-partykit.R
@@ -131,6 +131,19 @@ test_that("survival predictions", {
   )
 })
 
+test_that("can predict for out-of-domain timepoints", {
+  eval_time_obs_max_and_ood <- c(1022, 2000)
+  obs_without_NA <- lung[2,]
+
+  mod <- rand_forest() %>%
+    set_mode("censored regression") %>%
+    set_engine("partykit") %>%
+    fit(Surv(time, status) ~ ., data = lung)
+
+  expect_no_error(
+    preds <- predict(mod, obs_without_NA, type = "survival", eval_time = eval_time_obs_max_and_ood)
+  )
+})
 
 # fit via matrix interface ------------------------------------------------
 

--- a/tests/testthat/test-survival_reg-flexsurv.R
+++ b/tests/testthat/test-survival_reg-flexsurv.R
@@ -139,6 +139,24 @@ test_that("survival probabilities for single eval time point", {
   )
 })
 
+test_that("can predict for out-of-domain timepoints", {
+  eval_time_obs_max_and_ood <- c(1022, 2000)
+  obs_without_NA <- lung[2,]
+
+  mod <- survival_reg() %>%
+    set_mode("censored regression") %>%
+    set_engine("flexsurv") %>%
+    fit(Surv(time, status) ~ ., data = lung) %>%
+    suppressWarnings()
+
+  expect_no_error(
+    preds <- predict(mod, obs_without_NA, type = "survival", eval_time = eval_time_obs_max_and_ood)
+  )
+  expect_no_error(
+    preds <- predict(mod, obs_without_NA, type = "hazard", eval_time = eval_time_obs_max_and_ood)
+  )
+})
+
 # prediction: linear_pred -------------------------------------------------
 
 test_that("linear predictor", {

--- a/tests/testthat/test-survival_reg-flexsurvspline.R
+++ b/tests/testthat/test-survival_reg-flexsurvspline.R
@@ -143,6 +143,23 @@ test_that("survival probabilities for single eval time point", {
   )
 })
 
+test_that("can predict for out-of-domain timepoints", {
+  eval_time_obs_max_and_ood <- c(1022, 2000)
+  obs_without_NA <- lung[2,]
+
+  mod <- survival_reg() %>%
+    set_mode("censored regression") %>%
+    set_engine("flexsurvspline") %>%
+    fit(Surv(time, status) ~ ., data = lung)
+
+  expect_no_error(
+    preds <- predict(mod, obs_without_NA, type = "survival", eval_time = eval_time_obs_max_and_ood)
+  )
+  expect_no_error(
+    preds <- predict(mod, obs_without_NA, type = "hazard", eval_time = eval_time_obs_max_and_ood)
+  )
+})
+
 # prediction: linear_pred -------------------------------------------------
 
 test_that("linear predictor", {

--- a/tests/testthat/test-survival_reg-survival.R
+++ b/tests/testthat/test-survival_reg-survival.R
@@ -75,6 +75,22 @@ test_that("survival probability prediction", {
   expect_identical(nrow(f_pred_1), 1L)
 })
 
+test_that("can predict for out-of-domain timepoints", {
+  eval_time_obs_max_and_ood <- c(1022, 2000)
+  obs_without_NA <- lung[2,]
+
+  mod <- survival_reg() %>%
+    set_mode("censored regression") %>%
+    set_engine("survival") %>%
+    fit(Surv(time, status) ~ ., data = lung)
+
+  expect_no_error(
+    preds <- predict(mod, obs_without_NA, type = "survival", eval_time = eval_time_obs_max_and_ood)
+  )
+  expect_no_error(
+    preds <- predict(mod, obs_without_NA, type = "hazard", eval_time = eval_time_obs_max_and_ood)
+  )
+})
 
 # prediction: linear_pred -------------------------------------------------
 


### PR DESCRIPTION
closes #10

I've taken "out of domain" to mean eval time points not within the observed range of time points. This PR tests that this does cause censored to error and leaves the prediction value to the individual engines.