### PR TITLE
add `multi` arg to `survival_prob_coxnet()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * `extract_fit_engine()` now works properly for proportional hazards models fitted with the `"glmnet"` engine (#266).
 
-* `survival_time_coxnet()` and `survival_prob_coxnet()` gain a `multi` argument to allow multiple values for `penalty` (#278).
+* `survival_time_coxnet()` and `survival_prob_coxnet()` gain a `multi` argument to allow multiple values for `penalty` (#278, #279).
 
 
 # censored 0.2.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * `extract_fit_engine()` now works properly for proportional hazards models fitted with the `"glmnet"` engine (#266).
 
-* `survival_time_coxnet()` gained a `multi` argument to allow multiple values for `penalty` (#278).
+* `survival_time_coxnet()` and `survival_prob_coxnet()` gain a `multi` argument to allow multiple values for `penalty` (#278).
 
 
 # censored 0.2.0

--- a/R/aaa_survival_prob.R
+++ b/R/aaa_survival_prob.R
@@ -65,13 +65,21 @@ prob_template <- tibble::tibble(
 predict_survival_na <- function(eval_time, interval = "none", penalty = NULL) {
   if (!is.null(penalty)) {
     n_penalty <- length(penalty)
-    ret <- tibble(
-      penalty = rep(penalty, each = length(eval_time)),
-      .eval_time = rep(eval_time, times = n_penalty), 
-      .pred_survival = NA_real_
+    n_eval_time <- length(eval_time)
+    ret <- tibble::new_tibble(
+      list(
+        penalty = rep(penalty, each = n_eval_time),
+        .eval_time = rep(eval_time, times = n_penalty),
+        .pred_survival = rep(NA_real_, n_penalty * n_eval_time)
+      )
     )
   } else {
-    ret <- tibble(.eval_time = eval_time, .pred_survival = NA_real_)
+    ret <- tibble::new_tibble(
+      list(
+        .eval_time = eval_time,
+        .pred_survival = rep(NA_real_, length(eval_time))
+      )
+    )
   }
   
   if (interval == "confidence") {

--- a/R/aaa_survival_prob.R
+++ b/R/aaa_survival_prob.R
@@ -62,12 +62,23 @@ prob_template <- tibble::tibble(
 )
 
 
-predict_survival_na <- function(eval_time, interval = "none") {
-  ret <- tibble(.eval_time = eval_time, .pred_survival = NA_real_)
+predict_survival_na <- function(eval_time, interval = "none", penalty = NULL) {
+  if (!is.null(penalty)) {
+    n_penalty <- length(penalty)
+    ret <- tibble(
+      penalty = rep(penalty, each = length(eval_time)),
+      .eval_time = rep(eval_time, times = n_penalty), 
+      .pred_survival = NA_real_
+    )
+  } else {
+    ret <- tibble(.eval_time = eval_time, .pred_survival = NA_real_)
+  }
+  
   if (interval == "confidence") {
     ret <- ret %>%
       dplyr::mutate(.pred_lower = NA_real_, .pred_upper = NA_real_)
   }
+
   ret
 }
 

--- a/R/proportional_hazards-glmnet.R
+++ b/R/proportional_hazards-glmnet.R
@@ -520,6 +520,7 @@ get_missings_coxnet <- function(new_x, new_strata) {
 #' @param time Deprecated in favor of `eval_time`. A vector of integers for prediction times.
 #' @param output One of "surv" or "haz".
 #' @param penalty Penalty value(s).
+#' @param multi Allow multiple penalty values?
 #' @param ... Options to pass to [survival::survfit()].
 #' @return A tibble with a list column of nested tibbles.
 #' @keywords internal
@@ -535,6 +536,7 @@ survival_prob_coxnet <- function(object,
                                  time = deprecated(),
                                  output = "surv",
                                  penalty = NULL,
+                                 multi = FALSE,
                                  ...) {
   if (lifecycle::is_present(time)) {
     lifecycle::deprecate_warn(
@@ -549,14 +551,18 @@ survival_prob_coxnet <- function(object,
     penalty <- object$spec$args$penalty
   }
 
+  n_penalty <- length(penalty)
+  if (n_penalty > 1 & !multi) {
+    rlang::abort("Cannot use multiple penalty values with `multi = FALSE`.")
+  }
+
   output <- match.arg(output, c("surv", "haz"))
-  multi <- length(penalty) > 1
 
   new_x <- coxnet_prepare_x(new_data, object)
 
   went_through_formula_interface <- !is.null(object$preproc$coxnet)
   if (went_through_formula_interface &&
-    has_strata(object$formula, object$training_data)) {
+      has_strata(object$formula, object$training_data)) {
     new_strata <- get_strata_glmnet(
       object$formula,
       data = new_data,
@@ -573,7 +579,11 @@ survival_prob_coxnet <- function(object,
     n_missing <- length(missings_in_new_data)
     all_missing <- n_missing == n_obs
     if (all_missing) {
-      ret <- predict_survival_na(eval_time, interval = "none")
+      if (multi) {
+        ret <- predict_survival_na(eval_time, interval = "none", penalty = penalty)
+      } else {
+        ret <- predict_survival_na(eval_time, interval = "none")
+      }
       ret <- tibble(.pred = rep(list(ret), n_missing))
       return(ret)
     }
@@ -593,7 +603,7 @@ survival_prob_coxnet <- function(object,
     ...
   )
 
-  if (multi) {
+  if (length(penalty) > 1) {
     res_patched <- purrr::map(
       y,
       survfit_summary_to_patched_tibble,
@@ -601,25 +611,31 @@ survival_prob_coxnet <- function(object,
       eval_time = eval_time,
       n_obs = n_obs
     )
-    res <- tibble::tibble(
-      penalty = penalty,
-      res_patched = res_patched
-    ) %>%
-      tidyr::unnest(cols = res_patched) %>%
-      keep_cols(output, keep_penalty = TRUE) %>%
-      tidyr::nest(.pred = c(-.row)) %>%
-      dplyr::select(-.row)
   } else {
-    res <- survfit_summary_to_patched_tibble(
+    res_patched <- survfit_summary_to_patched_tibble(
       y,
       index_missing = missings_in_new_data,
       eval_time = eval_time,
       n_obs = n_obs
+    )
+  }
+
+  if (multi) {
+    res <- tibble::tibble(
+      penalty = penalty,
+      res_patched = res_patched
     ) %>%
+      tidyr::unnest(cols = res_patched)
+    res_formatted <- res %>%
+      keep_cols(output, keep_penalty = TRUE) %>%
+      tidyr::nest(.pred = c(-.row)) %>%
+      dplyr::select(-.row)
+  } else {
+    res_formatted <- res_patched %>%
       keep_cols(output) %>%
       tidyr::nest(.pred = c(-.row)) %>%
       dplyr::select(-.row)
   }
 
-  res
+  res_formatted
 }

--- a/R/proportional_hazards-glmnet.R
+++ b/R/proportional_hazards-glmnet.R
@@ -621,12 +621,11 @@ survival_prob_coxnet <- function(object,
   }
 
   if (multi) {
-    res <- tibble::tibble(
+    res_formatted <- tibble::tibble(
       penalty = penalty,
       res_patched = res_patched
     ) %>%
-      tidyr::unnest(cols = res_patched)
-    res_formatted <- res %>%
+      tidyr::unnest(cols = res_patched) %>%
       keep_cols(output, keep_penalty = TRUE) %>%
       tidyr::nest(.pred = c(-.row)) %>%
       dplyr::select(-.row)

--- a/R/proportional_hazards-glmnet.R
+++ b/R/proportional_hazards-glmnet.R
@@ -520,7 +520,7 @@ get_missings_coxnet <- function(new_x, new_strata) {
 #' @param time Deprecated in favor of `eval_time`. A vector of integers for prediction times.
 #' @param output One of "surv" or "haz".
 #' @param penalty Penalty value(s).
-#' @param multi Allow multiple penalty values?
+#' @param multi Allow multiple penalty values? Defaults to FALSE.
 #' @param ... Options to pass to [survival::survfit()].
 #' @return A tibble with a list column of nested tibbles.
 #' @keywords internal

--- a/man/survival_prob_coxnet.Rd
+++ b/man/survival_prob_coxnet.Rd
@@ -11,6 +11,7 @@ survival_prob_coxnet(
   time = deprecated(),
   output = "surv",
   penalty = NULL,
+  multi = FALSE,
   ...
 )
 }
@@ -26,6 +27,8 @@ survival_prob_coxnet(
 \item{output}{One of "surv" or "haz".}
 
 \item{penalty}{Penalty value(s).}
+
+\item{multi}{Allow multiple penalty values?}
 
 \item{...}{Options to pass to \code{\link[survival:survfit]{survival::survfit()}}.}
 }

--- a/man/survival_prob_coxnet.Rd
+++ b/man/survival_prob_coxnet.Rd
@@ -28,7 +28,7 @@ survival_prob_coxnet(
 
 \item{penalty}{Penalty value(s).}
 
-\item{multi}{Allow multiple penalty values?}
+\item{multi}{Allow multiple penalty values? Defaults to FALSE.}
 
 \item{...}{Options to pass to \code{\link[survival:survfit]{survival::survfit()}}.}
 }


### PR DESCRIPTION
This is part 1 of  #267

This does break `multi_predict(type = "survival")` temporarily but I think it'll be easier to review when the necessary changes to `multi_predict()` are coming in the next PR. 


``` r
library(censored)
#> Loading required package: parsnip
#> Loading required package: survival
lung2 <- lung[-14, ]

set.seed(14)
f_fit <- proportional_hazards(penalty = 0.123) %>%
  set_mode("censored regression") %>%
  set_engine("glmnet") %>%
  fit(Surv(time, status) ~ age + ph.ecog, data = lung2)

pred_multi <- survival_prob_coxnet(f_fit, new_data = lung2[1:3, c("age", "ph.ecog")],
                            eval_time = c(100, 200), penalty = 0.1, multi = TRUE)

# this should have a penalty column
pred_multi$.pred[[1]]
#> # A tibble: 2 × 3
#>   penalty .eval_time .pred_survival
#>     <dbl>      <dbl>          <dbl>
#> 1     0.1        100          0.868
#> 2     0.1        200          0.680
```

<sup>Created on 2023-12-18 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>