### PR TITLE
Confirm main args for `bag_tree(engine = "rpart")` work

### DIFF
--- a/tests/testthat/test-bag_tree-rpart.R
+++ b/tests/testthat/test-bag_tree-rpart.R
@@ -16,6 +16,27 @@ test_that("model object", {
   expect_equal(f_fit$fit[-6], exp_f_fit[-6], ignore_formula_env = TRUE)
 })
 
+test_that("main args work without set_model_arg()", {
+  set.seed(1234)
+  exp_f_fit <- ipred::bagging(
+    Surv(time, status) ~ age + ph.ecog, 
+    data = lung,
+    # already part of translate?
+    maxdepth = 20,
+    minsplit = 10,
+    cp = 0.5    
+  )
+
+  # formula method
+  mod_spec <- bag_tree(tree_depth = 20, min_n = 10, cost_complexity = 0.5) %>% 
+    set_mode("censored regression") %>%
+    set_engine("rpart")
+  set.seed(1234)
+  f_fit <- fit(mod_spec, Surv(time, status) ~ age + ph.ecog, data = lung)
+
+  # Removing `call` element from both
+  expect_equal(f_fit$fit[-6], exp_f_fit[-6], ignore_formula_env = TRUE)
+})
 
 # prediction: time --------------------------------------------------------
 


### PR DESCRIPTION
closes #7 

Even though we don't use `set_model_arg()`.