### PR TITLE
Harmonize inputs to `survival_*_*()` functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * Bug fix: `proportional_hazards(engine = "glmnet")` models now don't pretend to be able to deal with sparse matrices when they are not (#291).
 
+* Breaking change: The `survival_prob_*()`, `survival_time_*()`, and `hazard_*()` functions now all take a parsnip `model_fit` object as the main input, instead of an engine fit as was the case for some of them previously.
+
 
 # censored 0.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
 
 * Bug fix: `proportional_hazards(engine = "glmnet")` models now don't pretend to be able to deal with sparse matrices when they are not (#291).
 
-* Breaking change: The `survival_prob_*()`, `survival_time_*()`, and `hazard_*()` functions now all take a parsnip `model_fit` object as the main input, instead of an engine fit as was the case for some of them previously.
+* Breaking change: The `survival_prob_*()`, `survival_time_*()`, and `hazard_*()` functions now all take a parsnip `model_fit` object as the main input, instead of an engine fit as was the case for some of them previously (#302).
 
 
 # censored 0.2.0

--- a/R/bag_tree-data.R
+++ b/R/bag_tree-data.R
@@ -58,7 +58,7 @@ make_bag_tree_rpart <- function() {
       func = c(pkg = "censored", fun = "survival_time_survbagg"),
       args =
         list(
-          object = rlang::expr(object$fit),
+          object = rlang::expr(object),
           new_data = rlang::expr(new_data)
         )
     )
@@ -75,7 +75,7 @@ make_bag_tree_rpart <- function() {
       func = c(pkg = "censored", fun = "survival_prob_survbagg"),
       args =
         list(
-          object = rlang::expr(object$fit),
+          object = rlang::expr(object),
           new_data = rlang::expr(new_data),
           eval_time = rlang::expr(eval_time)
         )

--- a/R/bag_tree-rpart.R
+++ b/R/bag_tree-rpart.R
@@ -1,5 +1,5 @@
 #' A wrapper for survival times with `survbagg` models
-#' @param object A parsnip `model_fit` object resulting from `bag_tree()` with `engine = "rpart"`.
+#' @param object A parsnip `model_fit` object resulting from [bag_tree() with engine = "rpart"][parsnip::details_bag_tree_rpart].
 #' @param new_data Data for prediction
 #' @return A vector.
 #' @keywords internal
@@ -54,7 +54,7 @@ get_missings_survbagg <- function(object, new_data) {
 }
 
 #' A wrapper for survival probabilities with `survbagg` models
-#' @param object A parsnip `model_fit` object resulting from `bag_tree()` with `engine = "rpart"`.
+#' @param object A parsnip `model_fit` object resulting from [bag_tree() with engine = "rpart"][parsnip::details_bag_tree_rpart].
 #' @param new_data Data for prediction.
 #' @param eval_time A vector of prediction times.
 #' @param time Deprecated in favor of `eval_time`. A vector of prediction times.

--- a/R/bag_tree-rpart.R
+++ b/R/bag_tree-rpart.R
@@ -1,15 +1,21 @@
 #' A wrapper for survival times with `survbagg` models
-#' @param object A model from `ipred::bagging()`.
+#' @param object A parsnip `model_fit` object resulting from `bag_tree()` with `engine = "rpart"`.
 #' @param new_data Data for prediction
 #' @return A vector.
 #' @keywords internal
 #' @export
 #' @examples
-#' library(ipred)
-#' bagged_tree <- bagging(Surv(time, status) ~ age + ph.ecog, data = lung)
+#' bagged_tree <- bag_tree() %>%
+#'   set_engine("rpart") %>%
+#'   set_mode("censored regression") %>%
+#'   fit(Surv(time, status) ~ age + ph.ecog, data = lung)
 #' survival_time_survbagg(bagged_tree, lung[1:3, ])
 survival_time_survbagg <- function(object, new_data) {
-  missings_in_new_data <- get_missings_survbagg(object, new_data)
+  if (inherits(object, "survbagg")) {
+    cli::cli_abort("{.arg object} needs to be a parsnip {.cls model_fit} object, not a {.cls survbagg} object.")
+  }
+
+  missings_in_new_data <- get_missings_survbagg(object$fit, new_data)
   if (!is.null(missings_in_new_data)) {
     n_total <- nrow(new_data)
     n_missing <- length(missings_in_new_data)
@@ -21,7 +27,7 @@ survival_time_survbagg <- function(object, new_data) {
     new_data <- new_data[-missings_in_new_data, , drop = FALSE]
   }
 
-  y <- predict(object, newdata = new_data)
+  y <- predict(object$fit, newdata = new_data)
 
   res <- purrr::map_dbl(y, ~ quantile(.x, probs = .5)$quantile)
 
@@ -48,7 +54,7 @@ get_missings_survbagg <- function(object, new_data) {
 }
 
 #' A wrapper for survival probabilities with `survbagg` models
-#' @param object A model from `ipred::bagging()`.
+#' @param object A parsnip `model_fit` object resulting from `bag_tree()` with `engine = "rpart"`.
 #' @param new_data Data for prediction.
 #' @param eval_time A vector of prediction times.
 #' @param time Deprecated in favor of `eval_time`. A vector of prediction times.
@@ -56,10 +62,16 @@ get_missings_survbagg <- function(object, new_data) {
 #' @keywords internal
 #' @export
 #' @examples
-#' library(ipred)
-#' bagged_tree <- bagging(Surv(time, status) ~ age + ph.ecog, data = lung)
+#' bagged_tree <- bag_tree() %>%
+#'   set_engine("rpart") %>%
+#'   set_mode("censored regression") %>%
+#'   fit(Surv(time, status) ~ age + ph.ecog, data = lung)
 #' survival_prob_survbagg(bagged_tree, lung[1:3, ], eval_time = 100)
 survival_prob_survbagg <- function(object, new_data, eval_time, time = deprecated()) {
+  if (inherits(object, "survbagg")) {
+    cli::cli_abort("{.arg object} needs to be a parsnip {.cls model_fit} object, not a {.cls survbagg} object.")
+  }
+
   if (lifecycle::is_present(time)) {
     lifecycle::deprecate_warn(
       "0.2.0",
@@ -76,7 +88,7 @@ survival_prob_survbagg <- function(object, new_data, eval_time, time = deprecate
   output <- "surv"
 
   n_obs <- nrow(new_data)
-  missings_in_new_data <- get_missings_survbagg(object, new_data)
+  missings_in_new_data <- get_missings_survbagg(object$fit, new_data)
 
   if (!is.null(missings_in_new_data)) {
     n_missing <- length(missings_in_new_data)
@@ -89,7 +101,7 @@ survival_prob_survbagg <- function(object, new_data, eval_time, time = deprecate
     new_data <- new_data[-missings_in_new_data, , drop = FALSE]
   }
 
-  y <- predict(object, newdata = new_data)
+  y <- predict(object$fit, newdata = new_data)
 
   survfit_summary_list <- purrr::map(y, summary, times = eval_time, extend = TRUE)
   survfit_summary_combined <- combine_list_of_survfit_summary(

--- a/R/boost_tree-data.R
+++ b/R/boost_tree-data.R
@@ -103,7 +103,7 @@ make_boost_tree_mboost <- function() {
       post = NULL,
       func = c(pkg = "censored", fun = "survival_prob_mboost"),
       args = list(
-        object = rlang::expr(object$fit),
+        object = rlang::expr(object),
         new_data = rlang::expr(new_data),
         eval_time = rlang::expr(eval_time)
       )
@@ -138,7 +138,7 @@ make_boost_tree_mboost <- function() {
       func = c(pkg = "censored", fun = "survival_time_mboost"),
       args =
         list(
-          object = quote(object$fit),
+          object = quote(object),
           new_data = quote(new_data)
         )
     )

--- a/R/boost_tree-mboost.R
+++ b/R/boost_tree-mboost.R
@@ -112,8 +112,8 @@ predict_linear_pred._blackboost <- function(object,
 #' @keywords internal
 #' @export
 #' @examples
-#' mod <- bag_tree() %>%
-#'   set_engine("rpart") %>%
+#' mod <- boost_tree() %>%
+#'   set_engine("mboost") %>%
 #'   set_mode("censored regression") %>%
 #'   fit(Surv(time, status) ~ ., data = lung)
 #' survival_prob_mboost(mod, new_data = lung[1:3, ], eval_time = 300)
@@ -177,8 +177,8 @@ survival_curve_to_prob <- function(eval_time, event_times, survival_prob) {
 #' @keywords internal
 #' @export
 #' @examples
-#' boosted_tree <- bag_tree() %>%
-#'   set_engine("rpart") %>%
+#' boosted_tree <- boost_tree() %>%
+#'   set_engine("mboost") %>%
 #'   set_mode("censored regression") %>%
 #'   fit(Surv(time, status) ~ age + ph.ecog, data = lung[-14, ])
 #' survival_time_mboost(boosted_tree, new_data = lung[1:3, ])

--- a/R/boost_tree-mboost.R
+++ b/R/boost_tree-mboost.R
@@ -104,7 +104,7 @@ predict_linear_pred._blackboost <- function(object,
 }
 
 #' A wrapper for survival probabilities with mboost models
-#' @param object A parsnip `model_fit` object resulting from `boost_tree()` with `engine = "mboost"`.
+#' @param object A parsnip `model_fit` object resulting from [boost_tree() with engine = "mboost"][parsnip::details_boost_tree_mboost].
 #' @param new_data Data for prediction.
 #' @param eval_time A vector of integers for prediction times.
 #' @param time Deprecated in favor of `eval_time`. A vector of integers for prediction times.
@@ -171,7 +171,7 @@ survival_curve_to_prob <- function(eval_time, event_times, survival_prob) {
 
 
 #' A wrapper for mean survival times with `mboost` models
-#' @param object A parsnip `model_fit` object resulting from `boost_tree()` with `engine = "mboost"`.
+#' @param object A parsnip `model_fit` object resulting from [boost_tree() with engine = "mboost"][parsnip::details_boost_tree_mboost].
 #' @param new_data Data for prediction
 #' @return A tibble.
 #' @keywords internal

--- a/R/decision_tree-data.R
+++ b/R/decision_tree-data.R
@@ -174,7 +174,7 @@ make_decision_tree_partykit <- function() {
       post = NULL,
       func = c(pkg = "censored", fun = "survival_prob_partykit"),
       args = list(
-        object = rlang::expr(object$fit),
+        object = rlang::expr(object),
         new_data = rlang::expr(new_data),
         eval_time = rlang::expr(eval_time)
       )

--- a/R/decision_tree-rpart.R
+++ b/R/decision_tree-rpart.R
@@ -1,5 +1,5 @@
 #' A wrapper for survival probabilities with pecRpart models
-#' @param object A fitted `_pecRpart` object.
+#' @param object A parsnip `model_fit` object resulting from `decision_tree()` with `engine = "rpart"`.
 #' @param new_data Data for prediction.
 #' @param eval_time A vector of integers for prediction times.
 #' @return A tibble with a list column of nested tibbles.

--- a/R/decision_tree-rpart.R
+++ b/R/decision_tree-rpart.R
@@ -1,5 +1,5 @@
 #' A wrapper for survival probabilities with pecRpart models
-#' @param object A parsnip `model_fit` object resulting from `decision_tree()` with `engine = "rpart"`.
+#' @param object A parsnip `model_fit` object resulting from [decision_tree() with engine = "rpart"][parsnip::details_decision_tree_rpart].
 #' @param new_data Data for prediction.
 #' @param eval_time A vector of integers for prediction times.
 #' @return A tibble with a list column of nested tibbles.

--- a/R/partykit.R
+++ b/R/partykit.R
@@ -1,5 +1,6 @@
 #' A wrapper for survival probabilities with partykit models
-#' @param object A model object from `partykit::ctree()` or `partykit::cforest()`.
+#' @param object A parsnip `model_fit` object resulting from `bag_tree()` with 
+#' `engine = "partykit"` or from `rand_forest()` with `engine = "partykit"`.
 #' @param new_data A data frame to be predicted.
 #' @param eval_time A vector of times to predict the survival probability.
 #' @param time Deprecated in favor of `eval_time`. A vector of times to predict the survival probability.
@@ -8,16 +9,25 @@
 #' @export
 #' @keywords internal
 #' @examples
-#' library(partykit)
-#' c_tree <- ctree(Surv(time, status) ~ age + ph.ecog, data = lung)
-#' survival_prob_partykit(c_tree, lung[1:3, ], eval_time = 100)
-#' c_forest <- cforest(Surv(time, status) ~ age + ph.ecog, data = lung, ntree = 10)
-#' survival_prob_partykit(c_forest, lung[1:3, ], eval_time = 100)
+#' tree <- decision_tree() %>%
+#'   set_mode("censored regression") %>%
+#'   set_engine("partykit") %>%
+#'   fit(Surv(time, status) ~ age + ph.ecog, data = lung)
+#' survival_prob_partykit(tree, lung[1:3, ], eval_time = 100)
+#' forest <- rand_forest() %>%
+#'   set_mode("censored regression") %>%
+#'   set_engine("partykit") %>%
+#'   fit(Surv(time, status) ~ age + ph.ecog, data = lung)
+#' survival_prob_partykit(forest, lung[1:3, ], eval_time = 100)
 survival_prob_partykit <- function(object,
                                    new_data,
                                    eval_time,
                                    time = deprecated(),
                                    output = "surv") {
+  if (inherits(object, "party")) {
+    cli::cli_abort("{.arg object} needs to be a parsnip {.cls model_fit} object, not a {.cls party} object.")
+  }
+
   if (lifecycle::is_present(time)) {
     lifecycle::deprecate_warn(
       "0.2.0",
@@ -36,7 +46,7 @@ survival_prob_partykit <- function(object,
   # partykit handles missing values
   missings_in_new_data <- NULL
 
-  y <- predict(object, newdata = new_data, type = "prob")
+  y <- predict(object$fit, newdata = new_data, type = "prob")
 
   survfit_summary_list <- purrr::map(y, summary, times = eval_time, extend = TRUE)
   survfit_summary_combined <- combine_list_of_survfit_summary(

--- a/R/partykit.R
+++ b/R/partykit.R
@@ -1,6 +1,7 @@
 #' A wrapper for survival probabilities with partykit models
-#' @param object A parsnip `model_fit` object resulting from `bag_tree()` with 
-#' `engine = "partykit"` or from `rand_forest()` with `engine = "partykit"`.
+#' @param object A parsnip `model_fit` object resulting from 
+#' [decision_tree() with engine = "partykit"][parsnip::details_decision_tree_partykit] or 
+#' [rand_forest() with engine = "partykit"][parsnip::details_rand_forest_partykit].
 #' @param new_data A data frame to be predicted.
 #' @param eval_time A vector of times to predict the survival probability.
 #' @param time Deprecated in favor of `eval_time`. A vector of times to predict the survival probability.

--- a/R/proportional_hazards-data.R
+++ b/R/proportional_hazards-data.R
@@ -63,7 +63,7 @@ make_proportional_hazards_survival <- function() {
       func = c(pkg = "censored", fun = "survival_time_coxph"),
       args =
         list(
-          object = quote(object$fit),
+          object = quote(object),
           new_data = quote(new_data)
         )
     )
@@ -80,7 +80,7 @@ make_proportional_hazards_survival <- function() {
       func = c(pkg = "censored", fun = "survival_prob_coxph"),
       args =
         list(
-          x = quote(object$fit),
+          object = quote(object),
           new_data = quote(new_data),
           eval_time = rlang::expr(eval_time),
           output = "surv",

--- a/R/proportional_hazards-glmnet.R
+++ b/R/proportional_hazards-glmnet.R
@@ -462,7 +462,8 @@ multi_predict_coxnet_linear_pred <- function(object, new_data, opts, penalty) {
 # prediction: time --------------------------------------------------------
 
 #' A wrapper for survival times with coxnet models
-#' @param object A parsnip `model_fit` object resulting from `proportional_hazards()` with `engine = "glmnet"`.
+#' @param object A parsnip `model_fit` object resulting from 
+#' [proportional_hazards() with engine = "glmnet"][parsnip::details_proportional_hazards_glmnet].
 #' @param new_data Data for prediction.
 #' @param penalty Penalty value(s).
 #' @param multi Allow multiple penalty values?
@@ -583,7 +584,8 @@ get_missings_coxnet <- function(new_x, new_strata) {
 
 
 #' A wrapper for survival probabilities with coxnet models
-#' @param object A parsnip `model_fit` object resulting from `proportional_hazards()` with `engine = "glmnet"`.
+#' @param object A parsnip `model_fit` object resulting from 
+#' [proportional_hazards() with engine = "glmnet"][parsnip::details_proportional_hazards_glmnet].
 #' @param new_data Data for prediction.
 #' @param eval_time A vector of integers for prediction times.
 #' @param time Deprecated in favor of `eval_time`. A vector of integers for prediction times.

--- a/R/proportional_hazards-glmnet.R
+++ b/R/proportional_hazards-glmnet.R
@@ -462,7 +462,7 @@ multi_predict_coxnet_linear_pred <- function(object, new_data, opts, penalty) {
 # prediction: time --------------------------------------------------------
 
 #' A wrapper for survival times with coxnet models
-#' @param object A fitted `_coxnet` object.
+#' @param object A parsnip `model_fit` object resulting from `proportional_hazards()` with `engine = "glmnet"`.
 #' @param new_data Data for prediction.
 #' @param penalty Penalty value(s).
 #' @param multi Allow multiple penalty values?
@@ -583,7 +583,7 @@ get_missings_coxnet <- function(new_x, new_strata) {
 
 
 #' A wrapper for survival probabilities with coxnet models
-#' @param object A fitted `_coxnet` object.
+#' @param object A parsnip `model_fit` object resulting from `proportional_hazards()` with `engine = "glmnet"`.
 #' @param new_data Data for prediction.
 #' @param eval_time A vector of integers for prediction times.
 #' @param time Deprecated in favor of `eval_time`. A vector of integers for prediction times.

--- a/R/proportional_hazards-survival.R
+++ b/R/proportional_hazards-survival.R
@@ -46,7 +46,8 @@ cph_survival_pre <- function(new_data, object, ..., call = caller_env()) {
 # prediction: time --------------------------------------------------------
 
 #' A wrapper for survival times with `coxph` models
-#' @param object A parsnip `model_fit` object resulting from `proportional_hazards()` with `engine = "survival"`.
+#' @param object A parsnip `model_fit` object resulting from 
+#' [proportional_hazards() with engine = "survival"][parsnip::details_proportional_hazards_survival].
 #' @param new_data Data for prediction
 #' @return A vector.
 #' @keywords internal
@@ -111,7 +112,8 @@ get_missings_coxph <- function(object, new_data) {
 # prediction: survival ----------------------------------------------------
 
 #' A wrapper for survival probabilities with coxph models
-#' @param object A parsnip `model_fit` object resulting from `proportional_hazards()` with `engine = "survival"`.
+#' @param object A parsnip `model_fit` object resulting from 
+#' [proportional_hazards() with engine = "survival"][parsnip::details_proportional_hazards_survival].
 #' @param x Deprecated. A model from `coxph()`.
 #' @param new_data Data for prediction
 #' @param eval_time A vector of integers for prediction times.

--- a/R/rand_forest-aorsf.R
+++ b/R/rand_forest-aorsf.R
@@ -1,5 +1,5 @@
 #' Internal helper function for aorsf objects
-#' @param object A model object from `aorsf::orsf()`.
+#' @param object A parsnip `model_fit` object resulting from `rand_forest()` with `engine = "aorsf"`.
 #' @param new_data A data frame to be predicted.
 #' @param eval_time A vector of times to predict the survival probability.
 #' @param time Deprecated in favor of `eval_time`. A vector of times to predict the survival probability.
@@ -8,10 +8,15 @@
 #' @keywords internal
 #' @name aorsf_internal
 #' @examples
-#' library(aorsf)
-#' aorsf <- orsf(na.omit(lung), Surv(time, status) ~ age + ph.ecog, n_tree = 10)
-#' preds <- survival_prob_orsf(aorsf, lung[1:3, ], eval_time = c(250, 100))
+#' mod <- rand_forest() %>%
+#'   set_engine("aorsf") %>%
+#'   set_mode("censored regression") %>%
+#'   fit(Surv(time, status) ~ age + ph.ecog, data = na.omit(lung))
+#' preds <- survival_prob_orsf(mod, lung[1:3, ], eval_time = c(250, 100))
 survival_prob_orsf <- function(object, new_data, eval_time, time = deprecated()) {
+  if (inherits(object, "orsf_fit")) {
+    cli::cli_abort("{.arg object} needs to be a parsnip {.cls model_fit} object, not a {.cls orsf_fit} object.")
+  }
   if (lifecycle::is_present(time)) {
     lifecycle::deprecate_warn(
       "0.2.0",
@@ -22,7 +27,7 @@ survival_prob_orsf <- function(object, new_data, eval_time, time = deprecated())
   }
 
   pred <- predict(
-    object,
+    object$fit,
     new_data = new_data,
     pred_horizon = eval_time,
     pred_type = "surv",

--- a/R/rand_forest-aorsf.R
+++ b/R/rand_forest-aorsf.R
@@ -1,5 +1,6 @@
 #' Internal helper function for aorsf objects
-#' @param object A parsnip `model_fit` object resulting from `rand_forest()` with `engine = "aorsf"`.
+#' @param object A parsnip `model_fit` object resulting from 
+#' [rand_forest() with engine = "aorsf"][parsnip::details_rand_forest_aorsf].
 #' @param new_data A data frame to be predicted.
 #' @param eval_time A vector of times to predict the survival probability.
 #' @param time Deprecated in favor of `eval_time`. A vector of times to predict the survival probability.

--- a/R/rand_forest-data.R
+++ b/R/rand_forest-data.R
@@ -110,7 +110,7 @@ make_rand_forest_partykit <- function() {
       post = NULL,
       func = c(pkg = "censored", fun = "survival_prob_partykit"),
       args = list(
-        object = rlang::expr(object$fit),
+        object = rlang::expr(object),
         new_data = rlang::expr(new_data),
         eval_time = rlang::expr(eval_time)
       )

--- a/R/rand_forest-data.R
+++ b/R/rand_forest-data.R
@@ -196,7 +196,7 @@ make_rand_forest_aorsf <- function() {
       post = NULL,
       func = c(pkg = "censored", fun = "survival_prob_orsf"),
       args = list(
-        object = rlang::expr(object$fit),
+        object = rlang::expr(object),
         new_data = rlang::expr(new_data),
         eval_time = rlang::expr(eval_time)
       )

--- a/R/survival_reg-data.R
+++ b/R/survival_reg-data.R
@@ -109,7 +109,7 @@ make_survival_reg_survival <- function() {
       func = c(pkg = "censored", fun = "hazard_survreg"),
       args =
         list(
-          object = expr(object$fit),
+          object = expr(object),
           new_data = expr(new_data),
           eval_time = expr(eval_time)
         )
@@ -127,7 +127,7 @@ make_survival_reg_survival <- function() {
       func = c(pkg = "censored", fun = "survival_prob_survreg"),
       args =
         list(
-          object = expr(object$fit),
+          object = expr(object),
           new_data = expr(new_data),
           eval_time = expr(eval_time)
         )

--- a/R/survival_reg-survival.R
+++ b/R/survival_reg-survival.R
@@ -101,7 +101,8 @@ survreg_survival <- function(location, object, scale, eval_time, ...) {
 }
 
 #' Internal function helps for parametric survival models
-#' @param object A parsnip `model_fit` object resulting from `survival_reg()` with `engine = "survival"`.
+#' @param object A parsnip `model_fit` object resulting from 
+#' [survival_reg() with engine = "survival"][parsnip::details_survival_reg_survival].
 #' @param new_data A data frame.
 #' @param eval_time A vector of time points.
 #' @param time Deprecated in favor of `eval_time`. A vector of time points.

--- a/R/survival_reg-survival.R
+++ b/R/survival_reg-survival.R
@@ -101,7 +101,7 @@ survreg_survival <- function(location, object, scale, eval_time, ...) {
 }
 
 #' Internal function helps for parametric survival models
-#' @param object A `survreg` object.
+#' @param object A parsnip `model_fit` object resulting from `survival_reg()` with `engine = "survival"`.
 #' @param new_data A data frame.
 #' @param eval_time A vector of time points.
 #' @param time Deprecated in favor of `eval_time`. A vector of time points.
@@ -109,10 +109,15 @@ survreg_survival <- function(location, object, scale, eval_time, ...) {
 #' @keywords internal
 #' @export
 #' @examples
-#' surv_reg <- survreg(Surv(time, status) ~ ., data = lung)
-#' survival_prob_survreg(surv_reg, lung[1:3, ], eval_time = 100)
-#' hazard_survreg(surv_reg, lung[1:3, ], eval_time = 100)
+#' mod <- survival_reg() %>% 
+#'   set_engine("survival") %>%
+#'   fit(Surv(time, status) ~ ., data = lung)
+#' survival_prob_survreg(mod, lung[1:3, ], eval_time = 100)
+#' hazard_survreg(mod, lung[1:3, ], eval_time = 100)
 survival_prob_survreg <- function(object, new_data, eval_time, time = deprecated()) {
+  if (inherits(object, "survreg")) {
+    cli::cli_abort("{.arg object} needs to be a parsnip {.cls model_fit} object, not a {.cls survreg} object.")
+  }
   if (lifecycle::is_present(time)) {
     lifecycle::deprecate_warn(
       "0.2.0",
@@ -122,13 +127,13 @@ survival_prob_survreg <- function(object, new_data, eval_time, time = deprecated
     eval_time <- time
   }
 
-  lp_estimate <- predict(object, new_data, type = "lp")
-  scale_estimate <- get_survreg_scale(object, new_data)
+  lp_estimate <- predict(object$fit, new_data, type = "lp")
+  scale_estimate <- get_survreg_scale(object$fit, new_data)
   res <-
     purrr::map2(
       lp_estimate,
       scale_estimate,
-      ~ survreg_survival(.x, object = object, eval_time = eval_time, scale = .y)
+      ~ survreg_survival(.x, object = object$fit, eval_time = eval_time, scale = .y)
     )
   tibble::tibble(.pred = unname(res))
 }
@@ -147,13 +152,16 @@ survreg_hazard <- function(location, object, scale = object$scale, eval_time, ..
 #' @export
 #' @rdname survival_prob_survreg
 hazard_survreg <- function(object, new_data, eval_time) {
-  lp_estimate <- predict(object, new_data, type = "lp")
-  scale_estimate <- get_survreg_scale(object, new_data)
+  if (inherits(object, "survreg")) {
+    cli::cli_abort("{.arg object} needs to be a parsnip {.cls model_fit} object, not a {.cls survreg} object.")
+  }
+  lp_estimate <- predict(object$fit, new_data, type = "lp")
+  scale_estimate <- get_survreg_scale(object$fit, new_data)
   res <-
     purrr::map2(
       lp_estimate,
       scale_estimate,
-      ~ survreg_hazard(.x, object = object, eval_time = eval_time, scale = .y)
+      ~ survreg_hazard(.x, object = object$fit, eval_time = eval_time, scale = .y)
     )
   tibble::tibble(.pred = unname(res))
 }

--- a/man/aorsf_internal.Rd
+++ b/man/aorsf_internal.Rd
@@ -8,7 +8,8 @@
 survival_prob_orsf(object, new_data, eval_time, time = deprecated())
 }
 \arguments{
-\item{object}{A parsnip \code{model_fit} object resulting from \code{rand_forest()} with \code{engine = "aorsf"}.}
+\item{object}{A parsnip \code{model_fit} object resulting from
+\link[parsnip:details_rand_forest_aorsf]{rand_forest() with engine = "aorsf"}.}
 
 \item{new_data}{A data frame to be predicted.}
 

--- a/man/aorsf_internal.Rd
+++ b/man/aorsf_internal.Rd
@@ -8,7 +8,7 @@
 survival_prob_orsf(object, new_data, eval_time, time = deprecated())
 }
 \arguments{
-\item{object}{A model object from \code{aorsf::orsf()}.}
+\item{object}{A parsnip \code{model_fit} object resulting from \code{rand_forest()} with \code{engine = "aorsf"}.}
 
 \item{new_data}{A data frame to be predicted.}
 
@@ -23,8 +23,10 @@ A tibble with a list column of nested tibbles.
 Internal helper function for aorsf objects
 }
 \examples{
-library(aorsf)
-aorsf <- orsf(na.omit(lung), Surv(time, status) ~ age + ph.ecog, n_tree = 10)
-preds <- survival_prob_orsf(aorsf, lung[1:3, ], eval_time = c(250, 100))
+mod <- rand_forest() \%>\%
+  set_engine("aorsf") \%>\%
+  set_mode("censored regression") \%>\%
+  fit(Surv(time, status) ~ age + ph.ecog, data = na.omit(lung))
+preds <- survival_prob_orsf(mod, lung[1:3, ], eval_time = c(250, 100))
 }
 \keyword{internal}

--- a/man/survival_prob_coxnet.Rd
+++ b/man/survival_prob_coxnet.Rd
@@ -16,7 +16,8 @@ survival_prob_coxnet(
 )
 }
 \arguments{
-\item{object}{A parsnip \code{model_fit} object resulting from \code{proportional_hazards()} with \code{engine = "glmnet"}.}
+\item{object}{A parsnip \code{model_fit} object resulting from
+\link[parsnip:details_proportional_hazards_glmnet]{proportional_hazards() with engine = "glmnet"}.}
 
 \item{new_data}{Data for prediction.}
 

--- a/man/survival_prob_coxnet.Rd
+++ b/man/survival_prob_coxnet.Rd
@@ -16,7 +16,7 @@ survival_prob_coxnet(
 )
 }
 \arguments{
-\item{object}{A fitted \verb{_coxnet} object.}
+\item{object}{A parsnip \code{model_fit} object resulting from \code{proportional_hazards()} with \code{engine = "glmnet"}.}
 
 \item{new_data}{Data for prediction.}
 

--- a/man/survival_prob_coxph.Rd
+++ b/man/survival_prob_coxph.Rd
@@ -17,7 +17,8 @@ survival_prob_coxph(
 )
 }
 \arguments{
-\item{object}{A parsnip \code{model_fit} object resulting from \code{proportional_hazards()} with \code{engine = "survival"}.}
+\item{object}{A parsnip \code{model_fit} object resulting from
+\link[parsnip:details_proportional_hazards_survival]{proportional_hazards() with engine = "survival"}.}
 
 \item{x}{Deprecated. A model from \code{coxph()}.}
 

--- a/man/survival_prob_coxph.Rd
+++ b/man/survival_prob_coxph.Rd
@@ -5,7 +5,8 @@
 \title{A wrapper for survival probabilities with coxph models}
 \usage{
 survival_prob_coxph(
-  x,
+  object,
+  x = deprecated(),
   new_data,
   eval_time,
   time = deprecated(),
@@ -16,7 +17,9 @@ survival_prob_coxph(
 )
 }
 \arguments{
-\item{x}{A model from \code{coxph()}.}
+\item{object}{A parsnip \code{model_fit} object resulting from \code{proportional_hazards()} with \code{engine = "survival"}.}
+
+\item{x}{Deprecated. A model from \code{coxph()}.}
 
 \item{new_data}{Data for prediction}
 
@@ -40,7 +43,9 @@ A tibble with a list column of nested tibbles.
 A wrapper for survival probabilities with coxph models
 }
 \examples{
-cox_mod <- coxph(Surv(time, status) ~ ., data = lung)
+cox_mod <- proportional_hazards() \%>\% 
+  set_engine("survival") \%>\%
+  fit(Surv(time, status) ~ ., data = lung)
 survival_prob_coxph(cox_mod, new_data = lung[1:3, ], eval_time = 300)
 }
 \keyword{internal}

--- a/man/survival_prob_mboost.Rd
+++ b/man/survival_prob_mboost.Rd
@@ -22,8 +22,8 @@ A tibble with a list column of nested tibbles.
 A wrapper for survival probabilities with mboost models
 }
 \examples{
-mod <- bag_tree() \%>\%
-  set_engine("rpart") \%>\%
+mod <- boost_tree() \%>\%
+  set_engine("mboost") \%>\%
   set_mode("censored regression") \%>\%
   fit(Surv(time, status) ~ ., data = lung)
 survival_prob_mboost(mod, new_data = lung[1:3, ], eval_time = 300)

--- a/man/survival_prob_mboost.Rd
+++ b/man/survival_prob_mboost.Rd
@@ -7,7 +7,7 @@
 survival_prob_mboost(object, new_data, eval_time, time = deprecated())
 }
 \arguments{
-\item{object}{A model from \code{blackboost()}.}
+\item{object}{A parsnip \code{model_fit} object resulting from \code{boost_tree()} with \code{engine = "mboost"}.}
 
 \item{new_data}{Data for prediction.}
 
@@ -22,8 +22,10 @@ A tibble with a list column of nested tibbles.
 A wrapper for survival probabilities with mboost models
 }
 \examples{
-library(mboost)
-mod <- blackboost(Surv(time, status) ~ ., data = lung, family = CoxPH())
+mod <- bag_tree() \%>\%
+  set_engine("rpart") \%>\%
+  set_mode("censored regression") \%>\%
+  fit(Surv(time, status) ~ ., data = lung)
 survival_prob_mboost(mod, new_data = lung[1:3, ], eval_time = 300)
 }
 \keyword{internal}

--- a/man/survival_prob_mboost.Rd
+++ b/man/survival_prob_mboost.Rd
@@ -7,7 +7,7 @@
 survival_prob_mboost(object, new_data, eval_time, time = deprecated())
 }
 \arguments{
-\item{object}{A parsnip \code{model_fit} object resulting from \code{boost_tree()} with \code{engine = "mboost"}.}
+\item{object}{A parsnip \code{model_fit} object resulting from \link[parsnip:details_boost_tree_mboost]{boost_tree() with engine = "mboost"}.}
 
 \item{new_data}{Data for prediction.}
 

--- a/man/survival_prob_partykit.Rd
+++ b/man/survival_prob_partykit.Rd
@@ -13,7 +13,8 @@ survival_prob_partykit(
 )
 }
 \arguments{
-\item{object}{A model object from \code{partykit::ctree()} or \code{partykit::cforest()}.}
+\item{object}{A parsnip \code{model_fit} object resulting from \code{bag_tree()} with
+\code{engine = "partykit"} or from \code{rand_forest()} with \code{engine = "partykit"}.}
 
 \item{new_data}{A data frame to be predicted.}
 
@@ -30,10 +31,15 @@ A tibble with a list column of nested tibbles.
 A wrapper for survival probabilities with partykit models
 }
 \examples{
-library(partykit)
-c_tree <- ctree(Surv(time, status) ~ age + ph.ecog, data = lung)
-survival_prob_partykit(c_tree, lung[1:3, ], eval_time = 100)
-c_forest <- cforest(Surv(time, status) ~ age + ph.ecog, data = lung, ntree = 10)
-survival_prob_partykit(c_forest, lung[1:3, ], eval_time = 100)
+tree <- decision_tree() \%>\%
+  set_mode("censored regression") \%>\%
+  set_engine("partykit") \%>\%
+  fit(Surv(time, status) ~ age + ph.ecog, data = lung)
+survival_prob_partykit(tree, lung[1:3, ], eval_time = 100)
+forest <- rand_forest() \%>\%
+  set_mode("censored regression") \%>\%
+  set_engine("partykit") \%>\%
+  fit(Surv(time, status) ~ age + ph.ecog, data = lung)
+survival_prob_partykit(forest, lung[1:3, ], eval_time = 100)
 }
 \keyword{internal}

--- a/man/survival_prob_partykit.Rd
+++ b/man/survival_prob_partykit.Rd
@@ -13,8 +13,9 @@ survival_prob_partykit(
 )
 }
 \arguments{
-\item{object}{A parsnip \code{model_fit} object resulting from \code{bag_tree()} with
-\code{engine = "partykit"} or from \code{rand_forest()} with \code{engine = "partykit"}.}
+\item{object}{A parsnip \code{model_fit} object resulting from
+\link[parsnip:details_decision_tree_partykit]{decision_tree() with engine = "partykit"} or
+\link[parsnip:details_rand_forest_partykit]{rand_forest() with engine = "partykit"}.}
 
 \item{new_data}{A data frame to be predicted.}
 

--- a/man/survival_prob_pecRpart.Rd
+++ b/man/survival_prob_pecRpart.Rd
@@ -7,7 +7,7 @@
 survival_prob_pecRpart(object, new_data, eval_time)
 }
 \arguments{
-\item{object}{A fitted \verb{_pecRpart} object.}
+\item{object}{A parsnip \code{model_fit} object resulting from \code{decision_tree()} with \code{engine = "rpart"}.}
 
 \item{new_data}{Data for prediction.}
 

--- a/man/survival_prob_pecRpart.Rd
+++ b/man/survival_prob_pecRpart.Rd
@@ -7,7 +7,7 @@
 survival_prob_pecRpart(object, new_data, eval_time)
 }
 \arguments{
-\item{object}{A parsnip \code{model_fit} object resulting from \code{decision_tree()} with \code{engine = "rpart"}.}
+\item{object}{A parsnip \code{model_fit} object resulting from \link[parsnip:details_decision_tree_rpart]{decision_tree() with engine = "rpart"}.}
 
 \item{new_data}{Data for prediction.}
 

--- a/man/survival_prob_survbagg.Rd
+++ b/man/survival_prob_survbagg.Rd
@@ -7,7 +7,7 @@
 survival_prob_survbagg(object, new_data, eval_time, time = deprecated())
 }
 \arguments{
-\item{object}{A parsnip \code{model_fit} object resulting from \code{bag_tree()} with \code{engine = "rpart"}.}
+\item{object}{A parsnip \code{model_fit} object resulting from \link[parsnip:details_bag_tree_rpart]{bag_tree() with engine = "rpart"}.}
 
 \item{new_data}{Data for prediction.}
 

--- a/man/survival_prob_survbagg.Rd
+++ b/man/survival_prob_survbagg.Rd
@@ -7,7 +7,7 @@
 survival_prob_survbagg(object, new_data, eval_time, time = deprecated())
 }
 \arguments{
-\item{object}{A model from \code{ipred::bagging()}.}
+\item{object}{A parsnip \code{model_fit} object resulting from \code{bag_tree()} with \code{engine = "rpart"}.}
 
 \item{new_data}{Data for prediction.}
 
@@ -22,8 +22,10 @@ A vctrs list of tibbles.
 A wrapper for survival probabilities with \code{survbagg} models
 }
 \examples{
-library(ipred)
-bagged_tree <- bagging(Surv(time, status) ~ age + ph.ecog, data = lung)
+bagged_tree <- bag_tree() \%>\%
+  set_engine("rpart") \%>\%
+  set_mode("censored regression") \%>\%
+  fit(Surv(time, status) ~ age + ph.ecog, data = lung)
 survival_prob_survbagg(bagged_tree, lung[1:3, ], eval_time = 100)
 }
 \keyword{internal}

--- a/man/survival_prob_survreg.Rd
+++ b/man/survival_prob_survreg.Rd
@@ -10,7 +10,8 @@ survival_prob_survreg(object, new_data, eval_time, time = deprecated())
 hazard_survreg(object, new_data, eval_time)
 }
 \arguments{
-\item{object}{A parsnip \code{model_fit} object resulting from \code{survival_reg()} with \code{engine = "survival"}.}
+\item{object}{A parsnip \code{model_fit} object resulting from
+\link[parsnip:details_survival_reg_survival]{survival_reg() with engine = "survival"}.}
 
 \item{new_data}{A data frame.}
 

--- a/man/survival_prob_survreg.Rd
+++ b/man/survival_prob_survreg.Rd
@@ -10,7 +10,7 @@ survival_prob_survreg(object, new_data, eval_time, time = deprecated())
 hazard_survreg(object, new_data, eval_time)
 }
 \arguments{
-\item{object}{A \code{survreg} object.}
+\item{object}{A parsnip \code{model_fit} object resulting from \code{survival_reg()} with \code{engine = "survival"}.}
 
 \item{new_data}{A data frame.}
 
@@ -25,8 +25,10 @@ A tibble with a list column of nested tibbles.
 Internal function helps for parametric survival models
 }
 \examples{
-surv_reg <- survreg(Surv(time, status) ~ ., data = lung)
-survival_prob_survreg(surv_reg, lung[1:3, ], eval_time = 100)
-hazard_survreg(surv_reg, lung[1:3, ], eval_time = 100)
+mod <- survival_reg() \%>\% 
+  set_engine("survival") \%>\%
+  fit(Surv(time, status) ~ ., data = lung)
+survival_prob_survreg(mod, lung[1:3, ], eval_time = 100)
+hazard_survreg(mod, lung[1:3, ], eval_time = 100)
 }
 \keyword{internal}

--- a/man/survival_time_coxnet.Rd
+++ b/man/survival_time_coxnet.Rd
@@ -7,7 +7,7 @@
 survival_time_coxnet(object, new_data, penalty = NULL, multi = FALSE, ...)
 }
 \arguments{
-\item{object}{A fitted \verb{_coxnet} object.}
+\item{object}{A parsnip \code{model_fit} object resulting from \code{proportional_hazards()} with \code{engine = "glmnet"}.}
 
 \item{new_data}{Data for prediction.}
 

--- a/man/survival_time_coxnet.Rd
+++ b/man/survival_time_coxnet.Rd
@@ -7,7 +7,8 @@
 survival_time_coxnet(object, new_data, penalty = NULL, multi = FALSE, ...)
 }
 \arguments{
-\item{object}{A parsnip \code{model_fit} object resulting from \code{proportional_hazards()} with \code{engine = "glmnet"}.}
+\item{object}{A parsnip \code{model_fit} object resulting from
+\link[parsnip:details_proportional_hazards_glmnet]{proportional_hazards() with engine = "glmnet"}.}
 
 \item{new_data}{Data for prediction.}
 

--- a/man/survival_time_coxph.Rd
+++ b/man/survival_time_coxph.Rd
@@ -7,7 +7,8 @@
 survival_time_coxph(object, new_data)
 }
 \arguments{
-\item{object}{A parsnip \code{model_fit} object resulting from \code{proportional_hazards()} with \code{engine = "survival"}.}
+\item{object}{A parsnip \code{model_fit} object resulting from
+\link[parsnip:details_proportional_hazards_survival]{proportional_hazards() with engine = "survival"}.}
 
 \item{new_data}{Data for prediction}
 }

--- a/man/survival_time_coxph.Rd
+++ b/man/survival_time_coxph.Rd
@@ -7,7 +7,7 @@
 survival_time_coxph(object, new_data)
 }
 \arguments{
-\item{object}{A model from \code{coxph()}.}
+\item{object}{A parsnip \code{model_fit} object resulting from \code{proportional_hazards()} with \code{engine = "survival"}.}
 
 \item{new_data}{Data for prediction}
 }
@@ -18,7 +18,9 @@ A vector.
 A wrapper for survival times with \code{coxph} models
 }
 \examples{
-cox_mod <- coxph(Surv(time, status) ~ ., data = lung)
+cox_mod <- proportional_hazards() \%>\% 
+  set_engine("survival") \%>\%
+  fit(Surv(time, status) ~ ., data = lung)
 survival_time_coxph(cox_mod, new_data = lung[1:3, ])
 }
 \keyword{internal}

--- a/man/survival_time_mboost.Rd
+++ b/man/survival_time_mboost.Rd
@@ -7,7 +7,7 @@
 survival_time_mboost(object, new_data)
 }
 \arguments{
-\item{object}{A parsnip \code{model_fit} object resulting from \code{boost_tree()} with \code{engine = "mboost"}.}
+\item{object}{A parsnip \code{model_fit} object resulting from \link[parsnip:details_boost_tree_mboost]{boost_tree() with engine = "mboost"}.}
 
 \item{new_data}{Data for prediction}
 }

--- a/man/survival_time_mboost.Rd
+++ b/man/survival_time_mboost.Rd
@@ -7,7 +7,7 @@
 survival_time_mboost(object, new_data)
 }
 \arguments{
-\item{object}{A model from \code{blackboost()}.}
+\item{object}{A parsnip \code{model_fit} object resulting from \code{boost_tree()} with \code{engine = "mboost"}.}
 
 \item{new_data}{Data for prediction}
 }
@@ -18,10 +18,10 @@ A tibble.
 A wrapper for mean survival times with \code{mboost} models
 }
 \examples{
-library(mboost)
-boosted_tree <- blackboost(Surv(time, status) ~ age + ph.ecog,
-  data = lung[-14, ], family = CoxPH()
-)
+boosted_tree <- bag_tree() \%>\%
+  set_engine("rpart") \%>\%
+  set_mode("censored regression") \%>\%
+  fit(Surv(time, status) ~ age + ph.ecog, data = lung[-14, ])
 survival_time_mboost(boosted_tree, new_data = lung[1:3, ])
 }
 \keyword{internal}

--- a/man/survival_time_mboost.Rd
+++ b/man/survival_time_mboost.Rd
@@ -18,8 +18,8 @@ A tibble.
 A wrapper for mean survival times with \code{mboost} models
 }
 \examples{
-boosted_tree <- bag_tree() \%>\%
-  set_engine("rpart") \%>\%
+boosted_tree <- boost_tree() \%>\%
+  set_engine("mboost") \%>\%
   set_mode("censored regression") \%>\%
   fit(Surv(time, status) ~ age + ph.ecog, data = lung[-14, ])
 survival_time_mboost(boosted_tree, new_data = lung[1:3, ])

--- a/man/survival_time_survbagg.Rd
+++ b/man/survival_time_survbagg.Rd
@@ -7,7 +7,7 @@
 survival_time_survbagg(object, new_data)
 }
 \arguments{
-\item{object}{A parsnip \code{model_fit} object resulting from \code{bag_tree()} with \code{engine = "rpart"}.}
+\item{object}{A parsnip \code{model_fit} object resulting from \link[parsnip:details_bag_tree_rpart]{bag_tree() with engine = "rpart"}.}
 
 \item{new_data}{Data for prediction}
 }

--- a/man/survival_time_survbagg.Rd
+++ b/man/survival_time_survbagg.Rd
@@ -7,7 +7,7 @@
 survival_time_survbagg(object, new_data)
 }
 \arguments{
-\item{object}{A model from \code{ipred::bagging()}.}
+\item{object}{A parsnip \code{model_fit} object resulting from \code{bag_tree()} with \code{engine = "rpart"}.}
 
 \item{new_data}{Data for prediction}
 }
@@ -18,8 +18,10 @@ A vector.
 A wrapper for survival times with \code{survbagg} models
 }
 \examples{
-library(ipred)
-bagged_tree <- bagging(Surv(time, status) ~ age + ph.ecog, data = lung)
+bagged_tree <- bag_tree() \%>\%
+  set_engine("rpart") \%>\%
+  set_mode("censored regression") \%>\%
+  fit(Surv(time, status) ~ age + ph.ecog, data = lung)
 survival_time_survbagg(bagged_tree, lung[1:3, ])
 }
 \keyword{internal}

--- a/tests/testthat/_snaps/bag_tree-rpart.md
+++ b/tests/testthat/_snaps/bag_tree-rpart.md
@@ -1,0 +1,8 @@
+# survival_time_survbagg() throws an informative error with an engine object
+
+    Code
+      survival_time_survbagg(mod)
+    Condition
+      Error in `survival_time_survbagg()`:
+      ! `object` needs to be a parsnip <model_fit> object, not a <survbagg> object.
+

--- a/tests/testthat/test-boost_tree-mboost.R
+++ b/tests/testthat/test-boost_tree-mboost.R
@@ -161,15 +161,14 @@ test_that("survival_curve_to_prob() works", {
 
 test_that("survival_prob_mboost() works", {
   lung2 <- lung[-14, ]
-  mboost_object <- mboost::blackboost(
-    Surv(time, status) ~ age + ph.ecog,
-    data = lung2,
-    family = mboost::CoxPH()
-  )
+  mod <- boost_tree() %>%
+    set_engine("mboost") %>%
+    set_mode("censored regression") %>%
+    fit(Surv(time, status) ~ age + ph.ecog, data = lung2)
 
   # can handle missings
   pred <- survival_prob_mboost(
-    mboost_object,
+    mod,
     new_data = lung[14:15, ],
     eval_time = c(0, 100, 200)
   )
@@ -179,7 +178,7 @@ test_that("survival_prob_mboost() works", {
   # skip until mboost::survFit() works with a single row for `newdata`
   # fix submitted: https://github.com/boost-R/mboost/pull/118
   # pred <- survival_prob_mboost(
-  #   mboost_object,
+  #   mod,
   #   new_data = lung[1,],
   #   eval_time = c(0, 100, 200)
   # )

--- a/tests/testthat/test-partykit.R
+++ b/tests/testthat/test-partykit.R
@@ -1,7 +1,10 @@
 test_that("survival_prob_partykit() works for ctree", {
   set.seed(1234)
   # use only ph.ecog to rule out surrogate splits
-  mod <- partykit::ctree(Surv(time, status) ~ ph.ecog, data = lung)
+  mod <- decision_tree() %>%
+    set_mode("censored regression") %>%
+    set_engine("partykit") %>%
+    fit(Surv(time, status) ~ ph.ecog, data = lung)
 
   # time: combination of order, out-of-range, infinite
   pred_time <- c(-Inf, 0, 100, Inf, 1022, 3000)
@@ -9,7 +12,7 @@ test_that("survival_prob_partykit() works for ctree", {
   # multiple observations
   # (with 1 missing but partykit takes care of that)
   lung_pred <- lung[13:15, ]
-  surv_fit <- predict(mod, newdata = lung_pred, type = "prob")
+  surv_fit <- predict(mod$fit, newdata = lung_pred, type = "prob")
   surv_fit_summary <- purrr::map(
     surv_fit,
     summary,
@@ -37,7 +40,7 @@ test_that("survival_prob_partykit() works for ctree", {
 
   # single observation
   lung_pred <- lung[13, ]
-  surv_fit <- predict(mod, newdata = lung_pred, type = "prob")
+  surv_fit <- predict(mod$fit, newdata = lung_pred, type = "prob")
   surv_fit_summary <- purrr::map(
     surv_fit,
     summary,
@@ -72,7 +75,10 @@ test_that("survival_prob_partykit() works for cforest", {
   # partykit::cforest takes care of missing values via some form of randomness
   # hence set the seed before predicting on data with missings
 
-  mod <- partykit::cforest(Surv(time, status) ~ age + ph.ecog, data = lung)
+  mod <- rand_forest() %>%
+    set_mode("censored regression") %>%
+    set_engine("partykit") %>%
+    fit(Surv(time, status) ~ age + ph.ecog, data = lung)
 
   # time: combination of order, out-of-range, infinite
   pred_time <- c(-Inf, 0, 100, Inf, 1022, 3000)
@@ -80,7 +86,7 @@ test_that("survival_prob_partykit() works for cforest", {
   # multiple observations (with 1 missing)
   lung_pred <- lung[13:15, ]
   set.seed(1234)
-  surv_fit <- predict(mod, newdata = lung_pred, type = "prob")
+  surv_fit <- predict(mod$fit, newdata = lung_pred, type = "prob")
   surv_fit_summary <- purrr::map(
     surv_fit,
     summary,
@@ -110,7 +116,7 @@ test_that("survival_prob_partykit() works for cforest", {
   # single observation
   lung_pred <- lung[13, ]
   set.seed(1234)
-  surv_fit <- predict(mod, newdata = lung_pred, type = "prob")
+  surv_fit <- predict(mod$fit, newdata = lung_pred, type = "prob")
   surv_fit_summary <- purrr::map(
     surv_fit,
     summary,

--- a/tests/testthat/test-proportional_hazards-survival.R
+++ b/tests/testthat/test-proportional_hazards-survival.R
@@ -338,14 +338,15 @@ test_that("survival prediction with NA", {
 })
 
 test_that("survival_prob_coxph() works", {
-  mod <- coxph(Surv(time, status) ~ age + ph.ecog, data = lung)
+  mod <- proportional_hazards() %>% 
+    fit(Surv(time, status) ~ age + ph.ecog, data = lung)
 
   # time: combination of order, out-of-range, infinite
   pred_time <- c(-Inf, 0, 100, Inf, 1022, 3000)
 
   # multiple observations (with 1 missing)
   lung_pred <- lung[13:15, ]
-  surv_fit <- survfit(mod, newdata = lung_pred)
+  surv_fit <- survfit(mod$fit, newdata = lung_pred)
   surv_fit_summary <- summary(surv_fit, times = pred_time, extend = TRUE)
 
   prob <- survival_prob_coxph(mod, new_data = lung_pred, eval_time = pred_time)
@@ -373,7 +374,7 @@ test_that("survival_prob_coxph() works", {
 
   # single observation
   lung_pred <- lung[13, ]
-  surv_fit <- survfit(mod, newdata = lung_pred)
+  surv_fit <- survfit(mod$fit, newdata = lung_pred)
   surv_fit_summary <- summary(surv_fit, times = pred_time, extend = TRUE)
 
   prob <- survival_prob_coxph(mod, new_data = lung_pred, eval_time = pred_time)
@@ -401,14 +402,15 @@ test_that("survival_prob_coxph() works", {
 })
 
 test_that("survival_prob_coxph() works with confidence intervals", {
-  mod <- coxph(Surv(time, status) ~ age + ph.ecog, data = lung)
+  mod <- proportional_hazards() %>% 
+    fit(Surv(time, status) ~ age + ph.ecog, data = lung)
 
   # time: combination of order, out-of-range, infinite
   pred_time <- c(-Inf, 0, 100, Inf, 1022, 3000)
 
   # multiple observations (with 1 missing)
   lung_pred <- lung[13:15, ]
-  surv_fit <- survfit(mod, newdata = lung_pred)
+  surv_fit <- survfit(mod$fit, newdata = lung_pred)
 
   pred <- survival_prob_coxph(
     mod,


### PR DESCRIPTION
closes #295 

revdep checks come back clean:
```
ℹ Comparing results
✔ MachineShop 3.7.0                      ── E: 0     | W: 0     | N: 0    
✔ survex 1.2.0                           ── E: 0     | W: 0     | N: 0    
✔ tidyAML 0.0.4                          ── E: 0     | W: 0     | N: 0  
```