### PR TITLE
remove misregistered `decision_tree(engine = "partykit")` argument

### DIFF
--- a/R/decision_tree-data.R
+++ b/R/decision_tree-data.R
@@ -115,14 +115,6 @@ make_decision_tree_partykit <- function() {
     func = list(pkg = "dials", fun = "min_n"),
     has_submodel = FALSE
   )
-  parsnip::set_model_arg(
-    model = "decision_tree",
-    eng = "partykit",
-    parsnip = "mtry",
-    original = "mtry",
-    func = list(pkg = "dials", fun = "mtry"),
-    has_submodel = FALSE
-  )
 
   parsnip::set_fit(
     model = "decision_tree",


### PR DESCRIPTION
A bug in parsnip's machinery means that, if an argument is registered with `set_model_arg()` that's not actually a model argument, that argument will be "protected" when passed to the engine. We cleared up a good few of these mis-registrations in tidymodels/parsnip#1052 and related issues--this is the last mis-registration to clear up before we can return to parsnip and disallow registering model arguments that don't exist.

Unlike in the analogous PRs to parsnip and bonsai, I've opted not to include a NEWS entry since this is unlikely to affect any code--in the other examples, the registered argument was actually an engine argument, but `mtry` is neither in this case. 

With CRAN censored:

``` r
library(censored)
#> Loading required package: parsnip
#> Loading required package: survival

data(cancer)

dt_spec <- 
  decision_tree() %>%
  set_engine("partykit", mtry = 1) %>% 
  set_mode("censored regression") 

set.seed(1)
dt_fit <- dt_spec %>% fit(Surv(time, status) ~ ., data = na.omit(lung))
#> Warning: The following arguments cannot be manually modified and were removed:
#> mtry.
```

<sup>Created on 2024-04-07 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

With this PR:

``` r
dt_fit <- dt_spec %>% fit(Surv(time, status) ~ ., data = na.omit(lung))
```

<sup>Created on 2024-04-07 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

(Arguably, the CRAN behavior is probably preferred, _but_ `mtry` was only protected because of a bug in the way that parsnip checks for protected arguments!)
