### PR TITLE
Adapt for upcoming flexsurv version 2.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # censored (development version)
 
+* Internal changes to the `predict()` methods for flexsurv models, in preparation for the upcoming flexsurv release (#317).
+
+
 # censored 0.3.0
 
 ## New features

--- a/R/survival_reg-data.R
+++ b/R/survival_reg-data.R
@@ -257,21 +257,7 @@ make_survival_reg_flexsurv <- function() {
     type = "hazard",
     value = list(
       pre = NULL,
-      post = function(pred, object) {
-        if (".pred" %in% names(pred)) {
-          pred %>%
-            dplyr::rowwise() %>%
-            dplyr::mutate(
-              .pred = list(dplyr::rename(.pred, .eval_time = .time))
-            ) %>%
-            dplyr::ungroup()
-        } else {
-          dplyr::rename(pred, .eval_time = .time) %>%
-            dplyr::mutate(.row = seq_len(nrow(pred))) %>%
-            tidyr::nest(.by = .row) %>%
-            dplyr::select(-.row)
-        }
-      },
+      post = flexsurv_post,
       func = c(fun = "predict"),
       args =
         list(
@@ -290,21 +276,7 @@ make_survival_reg_flexsurv <- function() {
     type = "survival",
     value = list(
       pre = NULL,
-      post = function(pred, object) {
-        if (".pred" %in% names(pred)) {
-          pred %>%
-            dplyr::rowwise() %>%
-            dplyr::mutate(
-              .pred = list(dplyr::rename(.pred, .eval_time = .time))
-            ) %>%
-            dplyr::ungroup()
-        } else {
-          dplyr::rename(pred, .eval_time = .time) %>%
-            dplyr::mutate(.row = seq_len(nrow(pred))) %>%
-            tidyr::nest(.by = .row) %>%
-            dplyr::select(-.row)
-        }
-      },
+      post = flexsurv_post,
       func = c(fun = "predict"),
       args =
         list(
@@ -442,21 +414,7 @@ make_survival_reg_flexsurvspline <- function() {
     type = "hazard",
     value = list(
       pre = NULL,
-      post = function(pred, object) {
-        if (".pred" %in% names(pred)) {
-          pred %>%
-            dplyr::rowwise() %>%
-            dplyr::mutate(
-              .pred = list(dplyr::rename(.pred, .eval_time = .time))
-            ) %>%
-            dplyr::ungroup()
-        } else {
-          dplyr::rename(pred, .eval_time = .time) %>%
-            dplyr::mutate(.row = seq_len(nrow(pred))) %>%
-            tidyr::nest(.by = .row) %>%
-            dplyr::select(-.row)
-        }
-      },
+      post = flexsurv_post,
       func = c(fun = "predict"),
       args =
         list(
@@ -475,21 +433,7 @@ make_survival_reg_flexsurvspline <- function() {
     type = "survival",
     value = list(
       pre = NULL,
-      post = function(pred, object) {
-        if (".pred" %in% names(pred)) {
-          pred %>%
-            dplyr::rowwise() %>%
-            dplyr::mutate(
-              .pred = list(dplyr::rename(.pred, .eval_time = .time))
-            ) %>%
-            dplyr::ungroup()
-        } else {
-          dplyr::rename(pred, .eval_time = .time) %>%
-            dplyr::mutate(.row = seq_len(nrow(pred))) %>%
-            tidyr::nest(.by = .row) %>%
-            dplyr::select(-.row)
-        }
-      },
+      post = flexsurv_post,
       func = c(fun = "predict"),
       args =
         list(

--- a/R/survival_reg-flexsurv.R
+++ b/R/survival_reg-flexsurv.R
@@ -1,0 +1,29 @@
+flexsurv_post <- function(pred, object) {
+  if (packageVersion("flexsurv") < "2.3") {
+    pred <- flexsurv_rename_time(pred)
+  }
+
+  # if there's only one observation in new_data,
+  # flexsurv output isn't nested
+  if (!(".pred" %in% names(pred))) {
+    pred <- pred %>%
+      dplyr::mutate(.row = seq_len(nrow(pred))) %>%
+      tidyr::nest(.by = .row) %>%
+      dplyr::select(-.row)
+  }
+  pred 
+}
+
+flexsurv_rename_time <- function(pred){
+  if (".pred" %in% names(pred)) {
+    pred %>%
+      dplyr::rowwise() %>%
+      dplyr::mutate(
+        .pred = list(dplyr::rename(.pred, .eval_time = .time))
+      ) %>%
+      dplyr::ungroup()
+  } else {
+    pred %>%
+      dplyr::rename(.eval_time = .time)
+  }
+}

--- a/R/survival_reg-flexsurv.R
+++ b/R/survival_reg-flexsurv.R
@@ -1,5 +1,5 @@
 flexsurv_post <- function(pred, object) {
-  if (packageVersion("flexsurv") < "2.3") {
+  if (utils::packageVersion("flexsurv") < "2.3") {
     pred <- flexsurv_rename_time(pred)
   }
 

--- a/tests/testthat/test-survival_reg-flexsurvspline.R
+++ b/tests/testthat/test-survival_reg-flexsurvspline.R
@@ -61,12 +61,15 @@ test_that("survival probability prediction", {
     head(lung),
     type = "survival",
     times = c(0, 500, 1000)
-  ) %>%
-    dplyr::rowwise() %>%
-    dplyr::mutate(
-      .pred = list(dplyr::rename(.pred, .eval_time = .time))
-    ) %>%
-    dplyr::ungroup()
+  ) 
+  if (packageVersion("flexsurv") < "2.3") {
+    exp_pred <- exp_pred %>%
+      dplyr::rowwise() %>%
+      dplyr::mutate(
+        .pred = list(dplyr::rename(.pred, .eval_time = .time))
+      ) %>%
+      dplyr::ungroup()
+  }
 
   f_fit <- survival_reg() %>%
     set_engine("flexsurvspline", k = 1) %>%
@@ -281,12 +284,15 @@ test_that("hazard prediction", {
     head(lung),
     type = "hazard",
     times = c(0, 500, 1000)
-  ) %>%
-    dplyr::rowwise() %>%
-    dplyr::mutate(
-      .pred = list(dplyr::rename(.pred, .eval_time = .time))
-    ) %>%
-    dplyr::ungroup()
+  ) 
+  if (packageVersion("flexsurv") < "2.3") {
+    exp_pred <- exp_pred %>%
+      dplyr::rowwise() %>%
+      dplyr::mutate(
+        .pred = list(dplyr::rename(.pred, .eval_time = .time))
+      ) %>%
+      dplyr::ungroup()
+  }
 
   f_fit <- survival_reg() %>%
     set_engine("flexsurvspline", k = 1) %>%


### PR DESCRIPTION
In https://github.com/chjackson/flexsurv/pull/155 the name of the (evaluation) time column got renamed from `.time` to `.eval_time`. That change is heading for CRAN in the next version, so this PR updates censored to not rely on `.time` anymore to exist (in order to rename it anyway).