### PR TITLE
Update GHA

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -57,7 +57,7 @@ jobs:
           extra-packages: 
             any::rcmdcheck,
             aorsf=?ignore-before-r=4.2.0,
-            pec=?ignore-before-r=4.3.0
+            pec=?ignore-before-r=4.4.0
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2


### PR DESCRIPTION
pec's dependency rms needs R 4.4.0 so skip installing pec below that R version