### PR TITLE
Quiet warnings about a changing default for `cox.ties` in glmnet v5

### DIFF
--- a/tests/testthat/_snaps/proportional_hazards-glmnet.md
+++ b/tests/testthat/_snaps/proportional_hazards-glmnet.md
@@ -6,50 +6,59 @@
       parsnip model object
       
       
-      Call:  glmnet::glmnet(x = data_obj$x, y = data_obj$y, family = "cox",      weights = weights, alpha = alpha, lambda = lambda) 
+      Call:  glmnet::glmnet(x = data_obj$x, y = data_obj$y, family = "cox",      weights = weights, alpha = alpha, lambda = lambda, cox.ties = ..1) 
       
          Df %Dev   Lambda
-      1   0 0.00 0.225300
-      2   1 0.21 0.205300
-      3   1 0.39 0.187100
-      4   1 0.53 0.170500
-      5   1 0.65 0.155300
-      6   1 0.75 0.141500
-      7   1 0.84 0.128900
-      8   1 0.90 0.117500
-      9   1 0.96 0.107000
-      10  1 1.01 0.097540
-      11  1 1.05 0.088870
-      12  2 1.08 0.080980
-      13  2 1.13 0.073790
-      14  2 1.16 0.067230
-      15  2 1.19 0.061260
-      16  2 1.22 0.055820
-      17  2 1.24 0.050860
-      18  2 1.26 0.046340
-      19  2 1.27 0.042220
-      20  2 1.28 0.038470
-      21  2 1.29 0.035050
-      22  2 1.30 0.031940
-      23  2 1.31 0.029100
-      24  2 1.31 0.026520
-      25  2 1.32 0.024160
-      26  2 1.32 0.022010
-      27  2 1.33 0.020060
-      28  2 1.33 0.018280
-      29  2 1.33 0.016650
-      30  2 1.33 0.015170
-      31  2 1.33 0.013830
-      32  2 1.33 0.012600
-      33  2 1.34 0.011480
-      34  2 1.34 0.010460
-      35  2 1.34 0.009530
-      36  2 1.34 0.008683
-      37  2 1.34 0.007912
-      38  2 1.34 0.007209
-      39  2 1.34 0.006568
-      40  2 1.34 0.005985
-      41  2 1.34 0.005453
+      1   0 0.00 0.225800
+      2   1 0.20 0.205800
+      3   1 0.38 0.187500
+      4   1 0.52 0.170800
+      5   1 0.64 0.155600
+      6   1 0.74 0.141800
+      7   1 0.82 0.129200
+      8   1 0.88 0.117700
+      9   1 0.94 0.107300
+      10  1 0.99 0.097750
+      11  1 1.02 0.089070
+      12  2 1.05 0.081150
+      13  2 1.08 0.073940
+      14  2 1.10 0.067370
+      15  2 1.13 0.061390
+      16  2 1.16 0.055940
+      17  2 1.18 0.050970
+      18  2 1.20 0.046440
+      19  2 1.21 0.042310
+      20  2 1.23 0.038550
+      21  2 1.24 0.035130
+      22  2 1.25 0.032010
+      23  2 1.26 0.029160
+      24  2 1.27 0.026570
+      25  2 1.27 0.024210
+      26  2 1.28 0.022060
+      27  2 1.28 0.020100
+      28  2 1.28 0.018320
+      29  2 1.29 0.016690
+      30  2 1.29 0.015210
+      31  2 1.29 0.013860
+      32  2 1.30 0.012620
+      33  2 1.30 0.011500
+      34  2 1.30 0.010480
+      35  2 1.30 0.009550
+      36  2 1.30 0.008702
+      37  2 1.30 0.007929
+      38  2 1.30 0.007224
+      39  2 1.30 0.006583
+      40  2 1.30 0.005998
+      41  2 1.31 0.005465
+      42  2 1.31 0.004979
+      43  2 1.31 0.004537
+      44  2 1.31 0.004134
+      45  2 1.31 0.003767
+      46  2 1.31 0.003432
+      47  2 1.31 0.003127
+      48  2 1.31 0.002849
+      49  2 1.31 0.002596
+      50  2 1.31 0.002366
       The training data has been saved for prediction.
 
 # stratification is specified in a single term
@@ -101,76 +110,6 @@
 
 # predictions with strata and dot in formula
 
-    Code
-      f_fit <- fit(cox_spec, Surv(time, status) ~ . - sex + strata(sex), data = lung2)
-    Condition
-      Warning:
-      cox.fit: algorithm did not converge
-      Warning:
-      cox.fit: algorithm did not converge
-      Warning:
-      cox.fit: algorithm did not converge
-      Warning:
-      cox.fit: algorithm did not converge
-      Warning:
-      cox.fit: algorithm did not converge
-      Warning:
-      cox.fit: algorithm did not converge
-      Warning:
-      cox.fit: algorithm did not converge
-      Warning:
-      cox.fit: algorithm did not converge
-      Warning:
-      cox.fit: algorithm did not converge
-      Warning:
-      cox.fit: algorithm did not converge
-
----
-
-    Code
-      f_fit_2 <- fit(cox_spec, Surv(time, status) ~ ph.ecog + age + strata(sex),
-      data = lung2)
-    Condition
-      Warning:
-      cox.fit: algorithm did not converge
-      Warning:
-      cox.fit: algorithm did not converge
-      Warning:
-      cox.fit: algorithm did not converge
-      Warning:
-      cox.fit: algorithm did not converge
-      Warning:
-      cox.fit: algorithm did not converge
-      Warning:
-      cox.fit: algorithm did not converge
-      Warning:
-      cox.fit: algorithm did not converge
-      Warning:
-      cox.fit: algorithm did not converge
-      Warning:
-      cox.fit: algorithm did not converge
-      Warning:
-      cox.fit: algorithm did not converge
-
----
-
-    Code
-      predict(f_fit, lung2, type = "linear_pred")
-    Output
-      # A tibble: 227 x 1
-         .pred_linear_pred
-                     <dbl>
-       1            -1.09 
-       2            -0.579
-       3            -0.477
-       4            -0.940
-       5            -0.511
-       6            -1.09 
-       7            -1.49 
-       8            -1.51 
-       9            -0.906
-      10            -1.43 
-      # i 217 more rows
     Code
       predict(f_fit, lung2, type = "survival", eval_time = c(100, 300))
     Condition

--- a/tests/testthat/test-proportional_hazards-glmnet.R
+++ b/tests/testthat/test-proportional_hazards-glmnet.R
@@ -7,11 +7,13 @@ test_that("model object", {
   exp_f_fit <- glmnet(
     x = as.matrix(lung2[, c(4, 6)]),
     y = Surv(lung2$time, lung2$status),
-    family = "cox"
+    family = "cox",
+    cox.ties = "efron"
   )
 
   # formula method
-  cox_spec <- proportional_hazards(penalty = 0.123) |> set_engine("glmnet")
+  cox_spec <- proportional_hazards(penalty = 0.123) |>
+    set_engine("glmnet", cox.ties = "efron")
   expect_no_error(
     f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung2)
   )
@@ -23,7 +25,7 @@ test_that("model object", {
 test_that("print coxnet model", {
   lung2 <- lung[-14, ]
   f_fit <- proportional_hazards(penalty = 0.123) |>
-    set_engine("glmnet") |>
+    set_engine("glmnet", cox.ties = "efron") |>
     fit(Surv(time, status) ~ age + ph.ecog, data = lung2)
 
   expect_snapshot(f_fit)
@@ -40,13 +42,13 @@ test_that("time predictions without strata", {
   lung_y <- Surv(lung2$time, lung2$status)
   new_x <- as.matrix(lung2[1:3, c("age", "ph.ecog")])
   set.seed(14)
-  exp_f <- glmnet::glmnet(lung_x, lung_y, family = "cox")
+  exp_f <- glmnet::glmnet(lung_x, lung_y, family = "cox", cox.ties = "efron")
   exp_sf <- survfit(exp_f, newx = new_x, x = lung_x, y = lung_y, s = 0.1)
   exp_f_pred <- summary(exp_sf)$table[, "rmean"] |> unname()
 
   cox_spec <- proportional_hazards(penalty = 0.123) |>
     set_mode("censored regression") |>
-    set_engine("glmnet")
+    set_engine("glmnet", cox.ties = "efron")
   set.seed(14)
   f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung2)
 
@@ -80,7 +82,7 @@ test_that("time predictions with strata", {
   new_strata <- lung2$sex[1:3]
   set.seed(14)
   suppressWarnings(
-    exp_f <- glmnet::glmnet(lung_x, lung_y, family = "cox")
+    exp_f <- glmnet::glmnet(lung_x, lung_y, family = "cox", cox.ties = "efron")
   )
   exp_sf <- survfit(
     exp_f,
@@ -94,7 +96,7 @@ test_that("time predictions with strata", {
 
   cox_spec <- proportional_hazards(penalty = 0.123) |>
     set_mode("censored regression") |>
-    set_engine("glmnet")
+    set_engine("glmnet", cox.ties = "efron")
   set.seed(14)
   suppressWarnings(
     f_fit <- fit(
@@ -127,7 +129,7 @@ test_that("time predictions with NA in predictor", {
 
   suppressWarnings(
     f_fit <- proportional_hazards(penalty = 0.123) |>
-      set_engine("glmnet") |>
+      set_engine("glmnet", cox.ties = "efron") |>
       fit(Surv(time, status) ~ age + ph.ecog + strata(sex), data = lung2)
   )
 
@@ -172,7 +174,7 @@ test_that("time predictions with NA in strata", {
 
   suppressWarnings(
     f_fit <- proportional_hazards(penalty = 0.123) |>
-      set_engine("glmnet") |>
+      set_engine("glmnet", cox.ties = "efron") |>
       fit(Surv(time, status) ~ age + ph.ecog + strata(sex), data = lung2)
   )
 
@@ -221,11 +223,11 @@ test_that("survival_time_coxnet() works for single penalty value", {
   lung_y <- Surv(lung2$time, lung2$status)
 
   exp_f_fit <- suppressWarnings(
-    glmnet::glmnet(x = lung_x, y = lung_y, family = "cox")
+    glmnet::glmnet(x = lung_x, y = lung_y, family = "cox", cox.ties = "efron")
   )
   f_fit <- suppressWarnings(
     proportional_hazards(penalty = 0.1) |>
-      set_engine("glmnet") |>
+      set_engine("glmnet", cox.ties = "efron") |>
       fit(Surv(time, status) ~ age + ph.ecog, data = lung2)
   )
 
@@ -298,11 +300,11 @@ test_that("survival_time_coxnet() works for multiple penalty values", {
   lung_y <- Surv(lung2$time, lung2$status)
 
   exp_f_fit <- suppressWarnings(
-    glmnet::glmnet(x = lung_x, y = lung_y, family = "cox")
+    glmnet::glmnet(x = lung_x, y = lung_y, family = "cox", cox.ties = "efron")
   )
   f_fit <- suppressWarnings(
     proportional_hazards(penalty = 0.1) |>
-      set_engine("glmnet") |>
+      set_engine("glmnet", cox.ties = "efron") |>
       fit(Surv(time, status) ~ age + ph.ecog, data = lung2)
   )
 
@@ -411,7 +413,7 @@ test_that("survival probabilities without strata", {
 
   cox_spec <- proportional_hazards(penalty = 0.123) |>
     set_mode("censored regression") |>
-    set_engine("glmnet")
+    set_engine("glmnet", cox.ties = "efron")
 
   set.seed(14)
   expect_no_error(
@@ -513,7 +515,7 @@ test_that("survival probabilities without strata", {
 test_that("survival probabilities with strata", {
   cox_spec <- proportional_hazards(penalty = 0.123) |>
     set_mode("censored regression") |>
-    set_engine("glmnet")
+    set_engine("glmnet", cox.ties = "efron")
 
   set.seed(14)
   expect_no_error(
@@ -612,7 +614,7 @@ test_that("survival prediction with NA in predictor", {
 
   suppressWarnings(
     f_fit <- proportional_hazards(penalty = 0.123) |>
-      set_engine("glmnet") |>
+      set_engine("glmnet", cox.ties = "efron") |>
       fit(Surv(time, status) ~ age + ph.ecog + strata(sex), data = lung2)
   )
 
@@ -702,7 +704,7 @@ test_that("survival prediction with NA in strata", {
 
   suppressWarnings(
     f_fit <- proportional_hazards(penalty = 0.123) |>
-      set_engine("glmnet") |>
+      set_engine("glmnet", cox.ties = "efron") |>
       fit(Surv(time, status) ~ age + ph.ecog + strata(sex), data = lung2)
   )
 
@@ -796,11 +798,11 @@ test_that("survival_prob_coxnet() works for single penalty value", {
   lung_y <- Surv(lung2$time, lung2$status)
 
   exp_f_fit <- suppressWarnings(
-    glmnet::glmnet(x = lung_x, y = lung_y, family = "cox")
+    glmnet::glmnet(x = lung_x, y = lung_y, family = "cox", cox.ties = "efron")
   )
   f_fit <- suppressWarnings(
     proportional_hazards(penalty = 0.1) |>
-      set_engine("glmnet") |>
+      set_engine("glmnet", cox.ties = "efron") |>
       fit(Surv(time, status) ~ age + ph.ecog, data = lung2)
   )
 
@@ -880,11 +882,11 @@ test_that("survival_prob_coxnet() works for multiple penalty values", {
   lung_y <- Surv(lung2$time, lung2$status)
 
   exp_f_fit <- suppressWarnings(
-    glmnet::glmnet(x = lung_x, y = lung_y, family = "cox")
+    glmnet::glmnet(x = lung_x, y = lung_y, family = "cox", cox.ties = "efron")
   )
   f_fit <- suppressWarnings(
     proportional_hazards(penalty = 0.1) |>
-      set_engine("glmnet") |>
+      set_engine("glmnet", cox.ties = "efron") |>
       fit(Surv(time, status) ~ age + ph.ecog, data = lung2)
   )
 
@@ -987,7 +989,7 @@ test_that("can predict for out-of-domain timepoints", {
 
   mod <- proportional_hazards(penalty = 0.1) |>
     set_mode("censored regression") |>
-    set_engine("glmnet") |>
+    set_engine("glmnet", cox.ties = "efron") |>
     fit(Surv(time, status) ~ ., data = lung)
 
   expect_no_error(
@@ -1007,9 +1009,11 @@ test_that("linear_pred predictions without strata", {
   exp_f_fit <- glmnet::glmnet(
     x = as.matrix(lung2[, c(4, 6)]),
     y = Surv(lung2$time, lung2$status),
-    family = "cox"
+    family = "cox",
+    cox.ties = "efron"
   )
-  cox_spec <- proportional_hazards(penalty = 0.123) |> set_engine("glmnet")
+  cox_spec <- proportional_hazards(penalty = 0.123) |>
+    set_engine("glmnet", cox.ties = "efron")
   f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung2)
 
   # predict
@@ -1104,10 +1108,12 @@ test_that("linear_pred predictions with strata", {
     glmnet::glmnet(
       x = as.matrix(lung2[, c(4, 6)]),
       y = stratifySurv(Surv(lung2$time, lung2$status), lung2$sex),
-      family = "cox"
+      family = "cox",
+      cox.ties = "efron"
     )
   )
-  cox_spec <- proportional_hazards(penalty = 0.123) |> set_engine("glmnet")
+  cox_spec <- proportional_hazards(penalty = 0.123) |>
+    set_engine("glmnet", cox.ties = "efron")
   expect_no_error(
     suppressWarnings(
       f_fit <- fit(
@@ -1203,7 +1209,7 @@ test_that("linear_pred predictions with strata", {
 
 test_that("stratification is specified in a single term", {
   spec <- proportional_hazards(penalty = 0.123) |>
-    set_engine("glmnet")
+    set_engine("glmnet", cox.ties = "efron")
   expect_snapshot(error = TRUE, {
     fit(
       spec,
@@ -1235,7 +1241,7 @@ test_that("formula modifications to remove strata", {
 
   skip_if(R.version$major == "3")
   spec <- proportional_hazards(penalty = 0.1) |>
-    set_engine("glmnet")
+    set_engine("glmnet", cox.ties = "efron")
   expect_snapshot(error = TRUE, {
     fit(spec, Surv(time, status) ~ strata(sex), data = lung)
   })
@@ -1259,33 +1265,34 @@ test_that("predictions with strata and dot in formula", {
   # For R <= 3.6 only , glmnet models below give a warning for lack of convergence.
   skip_if(R.version$major == "3")
 
-  cox_spec <- proportional_hazards(penalty = 0.001) |> set_engine("glmnet")
+  cox_spec <- proportional_hazards(penalty = 0.001) |>
+    set_engine("glmnet", cox.ties = "efron")
   lung2 <- lung[, c("time", "status", "ph.ecog", "age", "sex")]
   lung2$sex <- factor(lung2$sex)
   lung2 <- lung2[complete.cases(lung2), ]
 
   # formula method
-  # expect warnings "cox.fit: algorithm did not converge"
-  expect_snapshot(
+  expect_no_error(
     f_fit <- fit(
       cox_spec,
       Surv(time, status) ~ . - sex + strata(sex),
       data = lung2
     )
   )
-  # expect warnings "cox.fit: algorithm did not converge"
-  expect_snapshot(
+  expect_no_error(
     f_fit_2 <- fit(
       cox_spec,
       Surv(time, status) ~ ph.ecog + age + strata(sex),
       data = lung2
     )
   )
-  # expect warnings "'to new 6 after EncodeVars()"
-  expect_snapshot({
+  expect_no_error(
     predict(f_fit, lung2, type = "linear_pred")
+  )
+  # expect warnings "'to new 6 after EncodeVars()"
+  expect_snapshot(
     predict(f_fit, lung2, type = "survival", eval_time = c(100, 300))
-  })
+  )
   expect_equal(
     predict(f_fit, lung2, type = "linear_pred"),
     predict(f_fit_2, lung2, type = "linear_pred")
@@ -1312,7 +1319,7 @@ test_that("`fit_xy()` works with matrix input", {
   lung_pred <- lung2[1:5, ]
 
   spec <- proportional_hazards(penalty = 0.1) |>
-    set_engine("glmnet")
+    set_engine("glmnet", cox.ties = "efron")
   f_fit <- fit(spec, Surv(time, status) ~ age + ph.ecog, data = lung2)
   xy_fit <- fit_xy(spec, x = lung_x, y = lung_y)
 
@@ -1348,7 +1355,7 @@ test_that("`fit_xy()` works with data frame input", {
   lung_pred <- lung2[1:5, ]
 
   spec <- proportional_hazards(penalty = 0.1) |>
-    set_engine("glmnet")
+    set_engine("glmnet", cox.ties = "efron")
   f_fit <- fit(spec, Surv(time, status) ~ age + ph.ecog, data = lung2)
   xy_fit <- fit_xy(spec, x = lung_x, y = lung_y)
 
@@ -1384,7 +1391,7 @@ test_that("`fit_xy()` errors with stratification", {
   lung_y_s <- glmnet::stratifySurv(lung_y, lung2$sex)
 
   spec <- proportional_hazards(penalty = 0.1) |>
-    set_engine("glmnet")
+    set_engine("glmnet", cox.ties = "efron")
 
   expect_snapshot(error = TRUE, {
     fit_xy(spec, x = lung_x, y = lung_y_s)
@@ -1400,7 +1407,7 @@ test_that("multi_predict(type = time)", {
   set.seed(14)
   f_fit <- proportional_hazards(penalty = 0.123) |>
     set_mode("censored regression") |>
-    set_engine("glmnet") |>
+    set_engine("glmnet", cox.ties = "efron") |>
     fit(Surv(time, status) ~ age + ph.ecog, data = lung2)
 
   pred_multi <- multi_predict(
@@ -1441,7 +1448,7 @@ test_that("multi_predict(type = survival) for multiple eval_time points", {
   set.seed(14)
   f_fit <- proportional_hazards(penalty = 0.123) |>
     set_mode("censored regression") |>
-    set_engine("glmnet") |>
+    set_engine("glmnet", cox.ties = "efron") |>
     fit(Surv(time, status) ~ age + ph.ecog, data = lung2)
 
   pred_multi <- multi_predict(
@@ -1484,7 +1491,7 @@ test_that("multi_predict(type = survival) for a single eval_time", {
   set.seed(14)
   f_fit <- proportional_hazards(penalty = 0.123) |>
     set_mode("censored regression") |>
-    set_engine("glmnet") |>
+    set_engine("glmnet", cox.ties = "efron") |>
     fit(Surv(time, status) ~ age + ph.ecog, data = lung2)
 
   pred_multi <- multi_predict(
@@ -1527,7 +1534,7 @@ test_that("multi_predict(type = linear_pred)", {
   set.seed(14)
   f_fit <- proportional_hazards(penalty = 0.123) |>
     set_mode("censored regression") |>
-    set_engine("glmnet") |>
+    set_engine("glmnet", cox.ties = "efron") |>
     fit(Surv(time, status) ~ age + ph.ecog, data = lung2)
 
   pred_multi <- multi_predict(
@@ -1569,12 +1576,13 @@ test_that("multi_predict(): type = raw", {
   exp_f_fit <- glmnet::glmnet(
     x = as.matrix(lung2[, c(4, 6)]),
     y = Surv(lung2$time, lung2$status),
-    family = "cox"
+    family = "cox",
+    cox.ties = "efron"
   )
   set.seed(14)
   f_fit <- proportional_hazards(penalty = 0.123) |>
     set_mode("censored regression") |>
-    set_engine("glmnet") |>
+    set_engine("glmnet", cox.ties = "efron") |>
     fit(Surv(time, status) ~ age + ph.ecog, data = lung2)
 
   exp_pred <- predict(
@@ -1614,7 +1622,7 @@ test_that("multi_predict(type = time) works with single penalty", {
   set.seed(14)
   f_fit <- proportional_hazards(penalty = 0.123) |>
     set_mode("censored regression") |>
-    set_engine("glmnet") |>
+    set_engine("glmnet", cox.ties = "efron") |>
     fit(Surv(time, status) ~ age + ph.ecog, data = lung2)
 
   pred_multi <- multi_predict(
@@ -1655,7 +1663,7 @@ test_that("multi_predict(type = survival) works with single penalty for multiple
   set.seed(14)
   f_fit <- proportional_hazards(penalty = 0.123) |>
     set_mode("censored regression") |>
-    set_engine("glmnet") |>
+    set_engine("glmnet", cox.ties = "efron") |>
     fit(Surv(time, status) ~ age + ph.ecog, data = lung2)
 
   pred_multi <- multi_predict(
@@ -1698,7 +1706,7 @@ test_that("multi_predict(type = survival) works with single penalty for a single
   set.seed(14)
   f_fit <- proportional_hazards(penalty = 0.123) |>
     set_mode("censored regression") |>
-    set_engine("glmnet") |>
+    set_engine("glmnet", cox.ties = "efron") |>
     fit(Surv(time, status) ~ age + ph.ecog, data = lung2)
 
   pred_multi <- multi_predict(
@@ -1741,7 +1749,7 @@ test_that("multi_predict(type = linear_pred) works with single penalty", {
   set.seed(14)
   f_fit <- proportional_hazards(penalty = 0.123) |>
     set_mode("censored regression") |>
-    set_engine("glmnet") |>
+    set_engine("glmnet", cox.ties = "efron") |>
     fit(Surv(time, status) ~ age + ph.ecog, data = lung2)
 
   pred_multi <- multi_predict(
@@ -1780,9 +1788,11 @@ test_that("multi_predict(type = raw) works with single penalty", {
   exp_f_fit <- glmnet::glmnet(
     x = as.matrix(lung2[, c(4, 6)]),
     y = Surv(lung2$time, lung2$status),
-    family = "cox"
+    family = "cox",
+    cox.ties = "efron"
   )
-  cox_spec <- proportional_hazards(penalty = 0.123) |> set_engine("glmnet")
+  cox_spec <- proportional_hazards(penalty = 0.123) |>
+    set_engine("glmnet", cox.ties = "efron")
   f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung2)
 
   f_pred <- multi_predict(f_fit, lung2, type = "raw", penalty = 0.01)
@@ -1808,7 +1818,7 @@ test_that("multi_predict(): type = NULL", {
   set.seed(14)
   f_fit <- proportional_hazards(penalty = 0.123) |>
     set_mode("censored regression") |>
-    set_engine("glmnet") |>
+    set_engine("glmnet", cox.ties = "efron") |>
     fit(Surv(time, status) ~ age + ph.ecog, data = lung2)
 
   pred_multi_null <- multi_predict(
@@ -1834,7 +1844,7 @@ test_that("multi_predict() recognises default penalty", {
   set.seed(14)
   f_fit <- proportional_hazards(penalty = 0.123) |>
     set_mode("censored regression") |>
-    set_engine("glmnet") |>
+    set_engine("glmnet", cox.ties = "efron") |>
     fit(Surv(time, status) ~ age + ph.ecog, data = lung2)
 
   # can use any prediction type to test
@@ -1862,7 +1872,8 @@ test_that("survival_time_coxnet() errors informatively on bad input", {
   raw_fit <- glmnet(
     x = as.matrix(lung2[, c("age", "ph.ecog")]),
     y = Surv(lung2$time, lung2$status),
-    family = "cox"
+    family = "cox",
+    cox.ties = "efron"
   )
   wrong_engine <- structure(
     list(fit = structure(list(), class = "coxph")),
@@ -1878,7 +1889,8 @@ test_that("survival_prob_coxnet() errors informatively on bad input", {
   raw_fit <- glmnet(
     x = as.matrix(lung2[, c("age", "ph.ecog")]),
     y = Surv(lung2$time, lung2$status),
-    family = "cox"
+    family = "cox",
+    cox.ties = "efron"
   )
   wrong_engine <- structure(
     list(fit = structure(list(), class = "coxph")),
@@ -1898,7 +1910,7 @@ test_that("survival_prob_coxnet() errors informatively on bad input", {
 test_that("survival_prob_coxnet() fails gracefully for eval_time values it can't handle", {
   lung2 <- lung[-14, ]
   mod <- proportional_hazards(penalty = 0.1) |>
-    set_engine("glmnet") |>
+    set_engine("glmnet", cox.ties = "efron") |>
     fit(Surv(time, status) ~ age + ph.ecog, data = lung2)
 
   expect_snapshot(
@@ -1914,7 +1926,7 @@ test_that("survival_prob_coxnet() fails gracefully for eval_time values it can't
 test_that("survival_prob_coxnet() accepts eval_time values that it can handle", {
   lung2 <- lung[-14, ]
   mod <- proportional_hazards(penalty = 0.1) |>
-    set_engine("glmnet") |>
+    set_engine("glmnet", cox.ties = "efron") |>
     fit(Surv(time, status) ~ age + ph.ecog, data = lung2)
   new_data <- lung2[1:2, ]
 


### PR DESCRIPTION
This suppresses a warning about the default changing and sets us up to remove this again once the default changed in the next version of glmnet.
