### PR TITLE
Build out the formula interface to glmnet

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # censored (development version)
 
+* Prediction for `proportional_hazards()` with the `"glmnet"` engine no longer fails on data with factors when fitted through `fit_xy()` (#365).
+
 * The `survival_prob_*()` and `hazard_*()` helpers now validate their inputs and return more informative error messages when given an unusable `object`, `new_data`, or `eval_time` (#271).
 
 # censored 0.3.4

--- a/R/proportional_hazards-glmnet.R
+++ b/R/proportional_hazards-glmnet.R
@@ -509,8 +509,6 @@ survival_time_coxnet <- function(
 
   new_x <- coxnet_prepare_x(new_data, object)
 
-  # strata can only enter via the formula API (`fit.proportional_hazards()`
-  # is the only path that sets `object$formula`)
   if (
     !is.null(object$formula) &&
       has_strata(object$formula, object$training_data)
@@ -673,8 +671,6 @@ survival_prob_coxnet <- function(
 
   new_x <- coxnet_prepare_x(new_data, object)
 
-  # strata can only enter via the formula API (`fit.proportional_hazards()`
-  # is the only path that sets `object$formula`)
   if (
     !is.null(object$formula) &&
       has_strata(object$formula, object$training_data)

--- a/R/proportional_hazards-glmnet.R
+++ b/R/proportional_hazards-glmnet.R
@@ -197,20 +197,11 @@ print._coxnet <- function(x, ...) {
 # prediction --------------------------------------------------------------
 
 coxnet_prepare_x <- function(new_data, object) {
-  went_through_formula_interface <- !is.null(object$preproc$coxnet)
-
-  if (went_through_formula_interface) {
-    new_x <- parsnip::.convert_form_to_xy_new(
-      object$preproc$coxnet,
-      new_data,
-      composition = "matrix"
-    )$x
-  } else {
-    new_x <- new_data[, object$preproc$x_var, drop = FALSE] |>
-      as.matrix()
-  }
-
-  new_x
+  parsnip::.convert_form_to_xy_new(
+    object$preproc$coxnet,
+    new_data,
+    composition = "matrix"
+  )$x
 }
 
 # notes adapted from parsnip:
@@ -518,9 +509,10 @@ survival_time_coxnet <- function(
 
   new_x <- coxnet_prepare_x(new_data, object)
 
-  went_through_formula_interface <- !is.null(object$preproc$coxnet)
+  # strata can only enter via the formula API (`fit.proportional_hazards()`
+  # is the only path that sets `object$formula`)
   if (
-    went_through_formula_interface &&
+    !is.null(object$formula) &&
       has_strata(object$formula, object$training_data)
   ) {
     new_strata <- get_strata_glmnet(
@@ -681,9 +673,10 @@ survival_prob_coxnet <- function(
 
   new_x <- coxnet_prepare_x(new_data, object)
 
-  went_through_formula_interface <- !is.null(object$preproc$coxnet)
+  # strata can only enter via the formula API (`fit.proportional_hazards()`
+  # is the only path that sets `object$formula`)
   if (
-    went_through_formula_interface &&
+    !is.null(object$formula) &&
       has_strata(object$formula, object$training_data)
   ) {
     new_strata <- get_strata_glmnet(

--- a/R/proportional_hazards.R
+++ b/R/proportional_hazards.R
@@ -54,6 +54,9 @@ fit_xy.proportional_hazards <- function(
     # res$fit$preproc carries it as used inside of `coxnet_train()`
     training_data_ind <- names(res$fit$preproc) %in% c("x", "y")
     res$training_data <- res$fit$preproc[training_data_ind]
+    # We are storing it in $preproc$coxnet rather than $preproc directly
+    # to be consistent with the formula interface `fit()`.
+    res$preproc$coxnet <- res$fit$preproc[!training_data_ind]
     res$fit <- res$fit$fit
   }
 

--- a/tests/testthat/test-proportional_hazards-glmnet.R
+++ b/tests/testthat/test-proportional_hazards-glmnet.R
@@ -1384,6 +1384,43 @@ test_that("`fit_xy()` works with data frame input", {
   expect_equal(f_pred_lp, xy_pred_lp)
 })
 
+test_that("`fit_xy()` works with factor predictors (#365)", {
+  lung2 <- lung[-14, ]
+  lung2$sex <- factor(lung2$sex)
+  lung_x <- lung2[, c("age", "ph.ecog", "sex")]
+  lung_y <- Surv(lung2$time, lung2$status)
+  lung_pred <- lung2[1:5, ]
+
+  spec <- proportional_hazards(penalty = 0.1) |>
+    set_engine("glmnet", cox.ties = "efron")
+  f_fit <- fit(spec, Surv(time, status) ~ age + ph.ecog + sex, data = lung2)
+  xy_fit <- fit_xy(spec, x = lung_x, y = lung_y)
+
+  expect_equal(f_fit$fit$fit, xy_fit$fit$fit)
+
+  f_pred_time <- predict(f_fit, new_data = lung_pred, type = "time")
+  xy_pred_time <- predict(xy_fit, new_data = lung_pred, type = "time")
+  expect_equal(f_pred_time, xy_pred_time)
+
+  f_pred_survival <- predict(
+    f_fit,
+    new_data = lung_pred,
+    type = "survival",
+    eval_time = c(100, 200)
+  )
+  xy_pred_survival <- predict(
+    xy_fit,
+    new_data = lung_pred,
+    type = "survival",
+    eval_time = c(100, 200)
+  )
+  expect_equal(f_pred_survival, xy_pred_survival)
+
+  f_pred_lp <- predict(f_fit, new_data = lung_pred, type = "linear_pred")
+  xy_pred_lp <- predict(xy_fit, new_data = lung_pred, type = "linear_pred")
+  expect_equal(f_pred_lp, xy_pred_lp)
+})
+
 test_that("`fit_xy()` errors with stratification", {
   lung2 <- lung[-14, ]
   lung_x <- as.matrix(lung2[, c("age", "ph.ecog")])

--- a/tests/testthat/test-proportional_hazards-glmnet.R
+++ b/tests/testthat/test-proportional_hazards-glmnet.R
@@ -1384,7 +1384,7 @@ test_that("`fit_xy()` works with data frame input", {
   expect_equal(f_pred_lp, xy_pred_lp)
 })
 
-test_that("`fit_xy()` works with factor predictors (#365)", {
+test_that("`fit_xy()` + prediction work with factor predictors (#365)", {
   lung2 <- lung[-14, ]
   lung2$sex <- factor(lung2$sex)
   lung_x <- lung2[, c("age", "ph.ecog", "sex")]


### PR DESCRIPTION
Closes #365

Because censored is essentially the formula interface to glment, at least for PH models, we need to also accept factors like a formula interface, even when using `fit_xy()` (like the rest of parsnip) and for `predict()` with such a model (like the rest of parsnip).

Reprex from the issue:
``` r
library(tidymodels)
library(censored)
#> Loading required package: survival
n <- 800

set.seed(403)
df <- data.frame(
  treatment = sample(c("A", "B", "C"), n, replace = TRUE),
  age = runif(n, 18, 99),
  #sex = sample(c("m", "f"), n, replace = TRUE),
  time = rexp(n),
  event = sample(c(0, 1), n, replace = TRUE)
) %>%
  filter(time > 0) %>%
  mutate(event_surv = Surv(time, event), .keep = "unused")

cv <- vfold_cv(df, v = 10)

spec <- proportional_hazards(penalty = 0.1, mixture = 1) %>%
  set_engine("glmnet", cox.ties = "efron") %>%
  set_mode("censored regression")

rec <- recipe(event_surv ~ ., data = df)

wflow <- workflow() %>%
  add_recipe(rec) %>%
  add_model(spec)

res <- fit_resamples(
  wflow,
  resamples = cv,
  metrics = metric_set(concordance_survival)
)
```

<sup>Created on 2026-05-22 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>