### PR TITLE
Add snapshot tests for deprecation of arguments

### DIFF
--- a/tests/testthat/_snaps/bag_tree-rpart.md
+++ b/tests/testthat/_snaps/bag_tree-rpart.md
@@ -54,3 +54,12 @@
       Error in `survival_prob_survbagg()`:
       ! `eval_time` can't contain missing values.
 
+# survival_prob_survbagg() warns about deprecated `time` argument
+
+    Code
+      pred_deprecated <- survival_prob_survbagg(mod, new_data = new_data, time = 100)
+    Condition
+      Warning:
+      The `time` argument of `survival_prob_survbagg()` is deprecated as of censored 0.2.0.
+      i Please use the `eval_time` argument instead.
+

--- a/tests/testthat/_snaps/boost_tree-mboost.md
+++ b/tests/testthat/_snaps/boost_tree-mboost.md
@@ -38,6 +38,15 @@
       Error in `survival_prob_mboost()`:
       ! `object$fit` must be a <mboost> object, not a <coxph> object.
 
+# survival_prob_mboost() warns about deprecated `time` argument
+
+    Code
+      pred_deprecated <- survival_prob_mboost(mod, new_data = new_data, time = 100)
+    Condition
+      Warning:
+      The `time` argument of `survival_prob_mboost()` is deprecated as of censored 0.2.0.
+      i Please use the `eval_time` argument instead.
+
 # multi_predict() errors informatively on bad input
 
     Code

--- a/tests/testthat/_snaps/partykit.md
+++ b/tests/testthat/_snaps/partykit.md
@@ -30,3 +30,12 @@
       Error in `survival_prob_partykit()`:
       ! `eval_time` can't contain missing values.
 
+# survival_prob_partykit() warns about deprecated `time` argument
+
+    Code
+      pred_deprecated <- survival_prob_partykit(mod, new_data = new_data, time = 100)
+    Condition
+      Warning:
+      The `time` argument of `survival_prob_partykit()` is deprecated as of censored 0.2.0.
+      i Please use the `eval_time` argument instead.
+

--- a/tests/testthat/_snaps/proportional_hazards-glmnet.md
+++ b/tests/testthat/_snaps/proportional_hazards-glmnet.md
@@ -149,6 +149,16 @@
       Error in `fit_xy()`:
       ! For stratification, please use the formula interface via `fit()`.
 
+# multi_predict() warns about deprecated `time` argument
+
+    Code
+      pred_deprecated <- multi_predict(f_fit, new_data = lung2[1:2, ], type = "survival",
+      time = c(100, 200), penalty = 0.1)
+    Condition
+      Warning:
+      The `time` argument of `multi_predict()` is deprecated as of censored 0.2.0.
+      i Please use the `eval_time` argument instead.
+
 # survival_time_coxnet() errors informatively on bad input
 
     Code
@@ -196,4 +206,13 @@
     Condition
       Error in `survival_prob_coxnet()`:
       ! `eval_time` can't contain missing values.
+
+# survival_prob_coxnet() warns about deprecated `time` argument
+
+    Code
+      pred_deprecated <- survival_prob_coxnet(mod, new_data = new_data, time = 100)
+    Condition
+      Warning:
+      The `time` argument of `survival_prob_coxnet()` is deprecated as of censored 0.2.0.
+      i Please use the `eval_time` argument instead.
 

--- a/tests/testthat/_snaps/proportional_hazards-survival.md
+++ b/tests/testthat/_snaps/proportional_hazards-survival.md
@@ -62,6 +62,24 @@
       Error in `survival_prob_coxph()`:
       ! `object$fit` must be a <coxph> object, not a <survreg> object.
 
+# survival_prob_coxph() warns about deprecated `time` argument
+
+    Code
+      pred_deprecated <- survival_prob_coxph(mod, new_data = new_data, time = 100)
+    Condition
+      Warning:
+      The `time` argument of `survival_prob_coxph()` is deprecated as of censored 0.2.0.
+      i Please use the `eval_time` argument instead.
+
+# survival_prob_coxph() errors about deprecated `x` argument
+
+    Code
+      survival_prob_coxph(mod, x = mod$fit, new_data = lung[1:2, ], eval_time = 100)
+    Condition
+      Error:
+      ! The `x` argument of `survival_prob_coxph()` was deprecated in censored 0.3.0 and is now defunct.
+      i Please use the `object` argument instead.
+
 # survival_prob_coxph() fails gracefully for eval_time values it can't handle
 
     Code

--- a/tests/testthat/_snaps/rand_forest-aorsf.md
+++ b/tests/testthat/_snaps/rand_forest-aorsf.md
@@ -46,3 +46,12 @@
       Error in `survival_prob_orsf()`:
       ! `eval_time` can't contain negative values.
 
+# survival_prob_orsf() warns about deprecated `time` argument
+
+    Code
+      pred_deprecated <- survival_prob_orsf(mod, new_data = new_data, time = 100)
+    Condition
+      Warning:
+      The `time` argument of `survival_prob_orsf()` is deprecated as of censored 0.2.0.
+      i Please use the `eval_time` argument instead.
+

--- a/tests/testthat/_snaps/survival_reg-survival.md
+++ b/tests/testthat/_snaps/survival_reg-survival.md
@@ -14,6 +14,15 @@
       Error in `predict()`:
       ! When using `type` values of "survival" or "hazard" a numeric vector `eval_time` should also be given.
 
+# survival_prob_survreg() warns about deprecated `time` argument
+
+    Code
+      pred_deprecated <- survival_prob_survreg(mod, new_data = new_data, time = 100)
+    Condition
+      Warning:
+      The `time` argument of `survival_prob_survreg()` is deprecated as of censored 0.2.0.
+      i Please use the `eval_time` argument instead.
+
 # survival_prob_survreg() errors informatively on bad input
 
     Code

--- a/tests/testthat/test-bag_tree-rpart.R
+++ b/tests/testthat/test-bag_tree-rpart.R
@@ -393,3 +393,24 @@ test_that("survival_prob_survbagg() accepts eval_time values that it can handle"
     )
   )
 })
+
+test_that("survival_prob_survbagg() warns about deprecated `time` argument", {
+  skip_if_not_installed("ipred")
+  mod <- bag_tree() |>
+    set_mode("censored regression") |>
+    set_engine("rpart") |>
+    fit(Surv(time, status) ~ age + ph.ecog, data = lung)
+  new_data <- lung[1:2, ]
+
+  expect_snapshot(
+    pred_deprecated <- survival_prob_survbagg(
+      mod,
+      new_data = new_data,
+      time = 100
+    )
+  )
+  expect_equal(
+    pred_deprecated,
+    survival_prob_survbagg(mod, new_data = new_data, eval_time = 100)
+  )
+})

--- a/tests/testthat/test-boost_tree-mboost.R
+++ b/tests/testthat/test-boost_tree-mboost.R
@@ -380,6 +380,27 @@ test_that("survival_prob_mboost() accepts eval_time values that it can handle", 
   )
 })
 
+test_that("survival_prob_mboost() warns about deprecated `time` argument", {
+  skip_if_not_installed("mboost")
+  mod <- boost_tree() |>
+    set_mode("censored regression") |>
+    set_engine("mboost") |>
+    fit(Surv(time, status) ~ age + ph.ecog, data = lung[-14, ])
+  new_data <- lung[1:2, ]
+
+  expect_snapshot(
+    pred_deprecated <- survival_prob_mboost(
+      mod,
+      new_data = new_data,
+      time = 100
+    )
+  )
+  expect_equal(
+    pred_deprecated,
+    survival_prob_mboost(mod, new_data = new_data, eval_time = 100)
+  )
+})
+
 # `multi_predict()` works for all `type`s available for `predict()` -------
 
 test_that("multi_predict(type = time)", {

--- a/tests/testthat/test-partykit.R
+++ b/tests/testthat/test-partykit.R
@@ -236,3 +236,25 @@ test_that("survival_prob_partykit() accepts eval_time values that it can handle"
     )
   )
 })
+
+test_that("survival_prob_partykit() warns about deprecated `time` argument", {
+  skip_if_not_installed("partykit")
+  skip_if_not_installed("coin")
+  mod <- decision_tree() |>
+    set_mode("censored regression") |>
+    set_engine("partykit") |>
+    fit(Surv(time, status) ~ age, data = lung)
+  new_data <- lung[1:2, ]
+
+  expect_snapshot(
+    pred_deprecated <- survival_prob_partykit(
+      mod,
+      new_data = new_data,
+      time = 100
+    )
+  )
+  expect_equal(
+    pred_deprecated,
+    survival_prob_partykit(mod, new_data = new_data, eval_time = 100)
+  )
+})

--- a/tests/testthat/test-proportional_hazards-glmnet.R
+++ b/tests/testthat/test-proportional_hazards-glmnet.R
@@ -1902,6 +1902,34 @@ test_that("multi_predict() recognises default penalty", {
   expect_identical(pred_multi, exp_pred_multi)
 })
 
+test_that("multi_predict() warns about deprecated `time` argument", {
+  lung2 <- lung[-14, ]
+  f_fit <- proportional_hazards(penalty = 0.123) |>
+    set_mode("censored regression") |>
+    set_engine("glmnet", cox.ties = "efron") |>
+    fit(Surv(time, status) ~ age + ph.ecog, data = lung2)
+
+  expect_snapshot(
+    pred_deprecated <- multi_predict(
+      f_fit,
+      new_data = lung2[1:2, ],
+      type = "survival",
+      time = c(100, 200),
+      penalty = 0.1
+    )
+  )
+  expect_equal(
+    pred_deprecated,
+    multi_predict(
+      f_fit,
+      new_data = lung2[1:2, ],
+      type = "survival",
+      eval_time = c(100, 200),
+      penalty = 0.1
+    )
+  )
+})
+
 # input checks ------------------------------------------------------------
 
 test_that("survival_time_coxnet() errors informatively on bad input", {
@@ -1982,5 +2010,25 @@ test_that("survival_prob_coxnet() accepts eval_time values that it can handle", 
       new_data = new_data,
       eval_time = c(100, 100, 200)
     )
+  )
+})
+
+test_that("survival_prob_coxnet() warns about deprecated `time` argument", {
+  lung2 <- lung[-14, ]
+  mod <- proportional_hazards(penalty = 0.1) |>
+    set_engine("glmnet", cox.ties = "efron") |>
+    fit(Surv(time, status) ~ age + ph.ecog, data = lung2)
+  new_data <- lung2[1:2, ]
+
+  expect_snapshot(
+    pred_deprecated <- survival_prob_coxnet(
+      mod,
+      new_data = new_data,
+      time = 100
+    )
+  )
+  expect_equal(
+    pred_deprecated,
+    survival_prob_coxnet(mod, new_data = new_data, eval_time = 100)
   )
 })

--- a/tests/testthat/test-proportional_hazards-survival.R
+++ b/tests/testthat/test-proportional_hazards-survival.R
@@ -930,6 +930,37 @@ test_that("survival_prob_coxph() errors informatively on bad input", {
   )
 })
 
+test_that("survival_prob_coxph() warns about deprecated `time` argument", {
+  mod <- proportional_hazards() |>
+    set_engine("survival") |>
+    fit(Surv(time, status) ~ age, data = lung)
+  new_data <- lung[1:2, ]
+
+  expect_snapshot(
+    pred_deprecated <- survival_prob_coxph(mod, new_data = new_data, time = 100)
+  )
+  expect_equal(
+    pred_deprecated,
+    survival_prob_coxph(mod, new_data = new_data, eval_time = 100)
+  )
+})
+
+test_that("survival_prob_coxph() errors about deprecated `x` argument", {
+  mod <- proportional_hazards() |>
+    set_engine("survival") |>
+    fit(Surv(time, status) ~ age, data = lung)
+
+  expect_snapshot(
+    error = TRUE,
+    survival_prob_coxph(
+      mod,
+      x = mod$fit,
+      new_data = lung[1:2, ],
+      eval_time = 100
+    )
+  )
+})
+
 test_that("survival_prob_coxph() fails gracefully for eval_time values it can't handle", {
   cox_mod <- proportional_hazards() |>
     set_engine("survival") |>

--- a/tests/testthat/test-rand_forest-aorsf.R
+++ b/tests/testthat/test-rand_forest-aorsf.R
@@ -389,3 +389,20 @@ test_that("survival_prob_orsf() accepts eval_time values that it can handle", {
     survival_prob_orsf(mod, new_data = new_data, eval_time = c(100, 100, 200))
   )
 })
+
+test_that("survival_prob_orsf() warns about deprecated `time` argument", {
+  skip_if_not_installed("aorsf")
+  mod <- rand_forest() |>
+    set_mode("censored regression") |>
+    set_engine("aorsf") |>
+    fit(Surv(time, status) ~ age + ph.ecog, data = na.omit(lung))
+  new_data <- lung[1:2, ]
+
+  expect_snapshot(
+    pred_deprecated <- survival_prob_orsf(mod, new_data = new_data, time = 100)
+  )
+  expect_equal(
+    pred_deprecated,
+    survival_prob_orsf(mod, new_data = new_data, eval_time = 100)
+  )
+})

--- a/tests/testthat/test-survival_reg-survival.R
+++ b/tests/testthat/test-survival_reg-survival.R
@@ -342,6 +342,25 @@ test_that("deprecation of `time` arg for type 'hazard'", {
   expect_identical(pred, exp_pred)
 })
 
+test_that("survival_prob_survreg() warns about deprecated `time` argument", {
+  mod <- survival_reg() |>
+    set_engine("survival") |>
+    fit(Surv(time, status) ~ age, data = lung)
+  new_data <- lung[1:2, ]
+
+  expect_snapshot(
+    pred_deprecated <- survival_prob_survreg(
+      mod,
+      new_data = new_data,
+      time = 100
+    )
+  )
+  expect_equal(
+    pred_deprecated,
+    survival_prob_survreg(mod, new_data = new_data, eval_time = 100)
+  )
+})
+
 # input checks ------------------------------------------------------------
 
 test_that("survival_prob_survreg() errors informatively on bad input", {


### PR DESCRIPTION
Since the helpers are exported, they also have deprecation warnings. Now we cover those as well.