### PR TITLE
Remove low value expectations

### DIFF
--- a/tests/testthat/test-bag_tree-rpart.R
+++ b/tests/testthat/test-bag_tree-rpart.R
@@ -9,9 +9,7 @@ test_that("model object", {
   # formula method
   mod_spec <- bag_tree(engine = "rpart") |> set_mode("censored regression")
   set.seed(1234)
-  expect_no_error(
-    f_fit <- fit(mod_spec, Surv(time, status) ~ age + ph.ecog, data = lung)
-  )
+  f_fit <- fit(mod_spec, Surv(time, status) ~ age + ph.ecog, data = lung)
 
   # Removing `call` element from both, it differs in the `data` arg
   expect_equal(f_fit$fit[-6], exp_f_fit[-6], ignore_formula_env = TRUE)
@@ -77,9 +75,7 @@ test_that("time predictions without surrogate splits for NA", {
   # lung$ph.ecog[14] is NA
   new_data_3 <- lung[13:15, ]
 
-  expect_no_error(
-    f_pred <- predict(f_fit, new_data_3, type = "time")
-  )
+  f_pred <- predict(f_fit, new_data_3, type = "time")
   expect_equal(nrow(f_pred), nrow(new_data_3))
   expect_equal(which(is.na(f_pred$.pred_time)), 2)
 })
@@ -235,13 +231,11 @@ test_that("survival predictions without surrogate splits for NA", {
   # lung$ph.ecog[14] is NA
   new_data_3 <- lung[13:15, ]
 
-  expect_no_error(
-    f_pred <- predict(
-      f_fit,
-      new_data_3,
-      type = "survival",
-      eval_time = c(100, 500, 1000)
-    )
+  f_pred <- predict(
+    f_fit,
+    new_data_3,
+    type = "survival",
+    eval_time = c(100, 500, 1000)
   )
   expect_equal(nrow(f_pred), nrow(new_data_3))
   expect_true(!any(is.na(f_pred$.pred[[1]]$.pred_survival)))

--- a/tests/testthat/test-boost_tree-mboost.R
+++ b/tests/testthat/test-boost_tree-mboost.R
@@ -14,9 +14,7 @@ test_that("model object", {
   cox_spec <- boost_tree() |>
     set_engine("mboost") |>
     set_mode("censored regression")
-  expect_no_error(
-    f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung2)
-  )
+  f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung2)
 
   # Removing `call` element from both
   expect_equal(

--- a/tests/testthat/test-decision_tree-partykit.R
+++ b/tests/testthat/test-decision_tree-partykit.R
@@ -12,9 +12,7 @@ test_that("model object", {
     set_mode("censored regression") |>
     set_engine("partykit")
   set.seed(1234)
-  expect_no_error(
-    f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung)
-  )
+  f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung)
 
   # Removing `call` element from comparison
   f_fit$fit$info$call <- NULL

--- a/tests/testthat/test-decision_tree-partykit.R
+++ b/tests/testthat/test-decision_tree-partykit.R
@@ -99,12 +99,11 @@ test_that("survival predictions", {
   # single observation
   f_pred <- predict(f_fit, lung[1, ], type = "survival", eval_time = 306)
   new_km <- predict(exp_f_fit, newdata = lung[1, ], type = "prob")[[1]]
-  # Prediction should be fairly near the actual value
+  exp_surv <- summary(new_km, times = 306, extend = TRUE)$surv
 
   expect_equal(
     f_pred$.pred[[1]]$.pred_survival,
-    new_km$surv[new_km$time == 306],
-    tolerance = .1
+    exp_surv
   )
 })
 

--- a/tests/testthat/test-decision_tree-rpart.R
+++ b/tests/testthat/test-decision_tree-rpart.R
@@ -11,9 +11,7 @@ test_that("model object", {
     set_mode("censored regression") |>
     set_engine("rpart")
   set.seed(1234)
-  expect_no_error(
-    f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung)
-  )
+  f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung)
 
   expect_equal(f_fit$fit, exp_f_fit, ignore_formula_env = TRUE)
 })

--- a/tests/testthat/test-null_model-survival.R
+++ b/tests/testthat/test-null_model-survival.R
@@ -6,9 +6,7 @@ test_that("model object ignores predictors", {
     set_engine("survival") |>
     set_mode("censored regression")
 
-  expect_no_error(
-    f_fit <- fit(spec, Surv(time, status) ~ ., data = lung)
-  )
+  f_fit <- fit(spec, Surv(time, status) ~ ., data = lung)
 
   exp_fit <- survfit(Surv(time, status) ~ 1, data = lung)
   expect_s3_class(f_fit$fit, "survfit")

--- a/tests/testthat/test-proportional_hazards-glmnet.R
+++ b/tests/testthat/test-proportional_hazards-glmnet.R
@@ -14,9 +14,7 @@ test_that("model object", {
   # formula method
   cox_spec <- proportional_hazards(penalty = 0.123) |>
     set_engine("glmnet", cox.ties = "efron")
-  expect_no_error(
-    f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung2)
-  )
+  f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung2)
 
   # Removing call element
   expect_equal(f_fit$fit[-11], exp_f_fit[-11])
@@ -56,7 +54,7 @@ test_that("time predictions without strata", {
   new_data_3 <- lung2[1:3, ]
   # should default to penalty value specified at fit time
   expect_no_error(
-    f_pred <- predict(f_fit, new_data = new_data_3, type = "time")
+    predict(f_fit, new_data = new_data_3, type = "time")
   )
   f_pred <- predict(f_fit, new_data = new_data_3, type = "time", penalty = 0.1)
 
@@ -110,7 +108,7 @@ test_that("time predictions with strata", {
   new_data_3 <- lung2[1:3, ]
   # should default to penalty value specified at fit time
   expect_no_error(
-    f_pred <- predict(f_fit, new_data = new_data_3, type = "time")
+    predict(f_fit, new_data = new_data_3, type = "time")
   )
   f_pred <- predict(f_fit, new_data = new_data_3, type = "time", penalty = 0.1)
 
@@ -416,13 +414,11 @@ test_that("survival probabilities without strata", {
     set_engine("glmnet", cox.ties = "efron")
 
   set.seed(14)
-  expect_no_error(
-    f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung2)
-  )
+  f_fit <- fit(cox_spec, Surv(time, status) ~ age + ph.ecog, data = lung2)
 
   # predict
   expect_no_error(
-    pred_1 <- predict(
+    predict(
       f_fit,
       new_data = lung2[1, ],
       type = "survival",
@@ -452,13 +448,11 @@ test_that("survival probabilities without strata", {
   )
 
   # single observation
-  expect_no_error(
-    f_pred_1 <- predict(
-      f_fit,
-      lung2[1, ],
-      type = "survival",
-      eval_time = c(100, 200)
-    )
+  f_pred_1 <- predict(
+    f_fit,
+    lung2[1, ],
+    type = "survival",
+    eval_time = c(100, 200)
   )
   expect_equal(nrow(f_pred_1), 1)
 
@@ -518,12 +512,10 @@ test_that("survival probabilities with strata", {
     set_engine("glmnet", cox.ties = "efron")
 
   set.seed(14)
-  expect_no_error(
-    f_fit <- fit(
-      cox_spec,
-      Surv(stop, event) ~ rx + size + number + strata(enum),
-      data = bladder
-    )
+  f_fit <- fit(
+    cox_spec,
+    Surv(stop, event) ~ rx + size + number + strata(enum),
+    data = bladder
   )
   new_data_3 <- bladder[1:3, ]
 
@@ -549,13 +541,11 @@ test_that("survival probabilities with strata", {
     ))
   )
   # single observation
-  expect_no_error(
-    f_pred_1 <- predict(
-      f_fit,
-      bladder[1, ],
-      type = "survival",
-      eval_time = c(10, 20)
-    )
+  f_pred_1 <- predict(
+    f_fit,
+    bladder[1, ],
+    type = "survival",
+    eval_time = c(10, 20)
   )
   expect_equal(nrow(f_pred_1), 1)
 
@@ -629,71 +619,59 @@ test_that("survival prediction with NA in predictor", {
   na_1_data_0 <- lung[14, ]
 
   # survival probabilities
-  expect_no_error(
-    f_pred <- predict(
-      f_fit,
-      na_x_data_x,
-      type = "survival",
-      eval_time = c(306, 455)
-    )
+  f_pred <- predict(
+    f_fit,
+    na_x_data_x,
+    type = "survival",
+    eval_time = c(306, 455)
   )
   expect_equal(nrow(f_pred), nrow(na_x_data_x))
   expect_true(all(is.na(f_pred$.pred[[2]]$.pred_survival)))
   expect_true(all(is.na(f_pred$.pred[[4]]$.pred_survival)))
 
-  expect_no_error(
-    f_pred <- predict(
-      f_fit,
-      na_x_data_1,
-      type = "survival",
-      eval_time = c(306, 455)
-    )
+  f_pred <- predict(
+    f_fit,
+    na_x_data_1,
+    type = "survival",
+    eval_time = c(306, 455)
   )
   expect_equal(nrow(f_pred), nrow(na_x_data_1))
   expect_true(all(is.na(f_pred$.pred[[2]]$.pred_survival)))
   expect_true(all(is.na(f_pred$.pred[[3]]$.pred_survival)))
 
-  expect_no_error(
-    f_pred <- predict(
-      f_fit,
-      na_x_data_0,
-      type = "survival",
-      eval_time = c(306, 455)
-    )
+  f_pred <- predict(
+    f_fit,
+    na_x_data_0,
+    type = "survival",
+    eval_time = c(306, 455)
   )
   expect_equal(nrow(f_pred), nrow(na_x_data_0))
   expect_true(all(is.na(f_pred$.pred[[1]]$.pred_survival)))
   expect_true(all(is.na(f_pred$.pred[[2]]$.pred_survival)))
 
-  expect_no_error(
-    f_pred <- predict(
-      f_fit,
-      na_1_data_x,
-      type = "survival",
-      eval_time = c(306, 455)
-    )
+  f_pred <- predict(
+    f_fit,
+    na_1_data_x,
+    type = "survival",
+    eval_time = c(306, 455)
   )
   expect_equal(nrow(f_pred), nrow(na_1_data_x))
   expect_true(all(is.na(f_pred$.pred[[2]]$.pred_survival)))
 
-  expect_no_error(
-    f_pred <- predict(
-      f_fit,
-      na_1_data_1,
-      type = "survival",
-      eval_time = c(306, 455)
-    )
+  f_pred <- predict(
+    f_fit,
+    na_1_data_1,
+    type = "survival",
+    eval_time = c(306, 455)
   )
   expect_equal(nrow(f_pred), nrow(na_1_data_1))
   expect_true(all(is.na(f_pred$.pred[[2]]$.pred_survival)))
 
-  expect_no_error(
-    f_pred <- predict(
-      f_fit,
-      na_1_data_0,
-      type = "survival",
-      eval_time = c(306, 455)
-    )
+  f_pred <- predict(
+    f_fit,
+    na_1_data_0,
+    type = "survival",
+    eval_time = c(306, 455)
   )
   expect_equal(nrow(f_pred), nrow(na_1_data_0))
   expect_true(all(is.na(f_pred$.pred[[1]]$.pred_survival)))
@@ -719,71 +697,59 @@ test_that("survival prediction with NA in strata", {
   na_1_data_0 <- lung2[2, ]
 
   # survival probabilities
-  expect_no_error(
-    f_pred <- predict(
-      f_fit,
-      na_x_data_x,
-      type = "survival",
-      eval_time = c(306, 455)
-    )
+  f_pred <- predict(
+    f_fit,
+    na_x_data_x,
+    type = "survival",
+    eval_time = c(306, 455)
   )
   expect_equal(nrow(f_pred), nrow(na_x_data_x))
   expect_true(all(is.na(f_pred$.pred[[2]]$.pred_survival)))
   expect_true(all(is.na(f_pred$.pred[[4]]$.pred_survival)))
 
-  expect_no_error(
-    f_pred <- predict(
-      f_fit,
-      na_x_data_1,
-      type = "survival",
-      eval_time = c(306, 455)
-    )
+  f_pred <- predict(
+    f_fit,
+    na_x_data_1,
+    type = "survival",
+    eval_time = c(306, 455)
   )
   expect_equal(nrow(f_pred), nrow(na_x_data_1))
   expect_true(all(is.na(f_pred$.pred[[2]]$.pred_survival)))
   expect_true(all(is.na(f_pred$.pred[[3]]$.pred_survival)))
 
-  expect_no_error(
-    f_pred <- predict(
-      f_fit,
-      na_x_data_0,
-      type = "survival",
-      eval_time = c(306, 455)
-    )
+  f_pred <- predict(
+    f_fit,
+    na_x_data_0,
+    type = "survival",
+    eval_time = c(306, 455)
   )
   expect_equal(nrow(f_pred), nrow(na_x_data_0))
   expect_true(all(is.na(f_pred$.pred[[1]]$.pred_survival)))
   expect_true(all(is.na(f_pred$.pred[[2]]$.pred_survival)))
 
-  expect_no_error(
-    f_pred <- predict(
-      f_fit,
-      na_1_data_x,
-      type = "survival",
-      eval_time = c(306, 455)
-    )
+  f_pred <- predict(
+    f_fit,
+    na_1_data_x,
+    type = "survival",
+    eval_time = c(306, 455)
   )
   expect_equal(nrow(f_pred), nrow(na_1_data_x))
   expect_true(all(is.na(f_pred$.pred[[2]]$.pred_survival)))
 
-  expect_no_error(
-    f_pred <- predict(
-      f_fit,
-      na_1_data_1,
-      type = "survival",
-      eval_time = c(306, 455)
-    )
+  f_pred <- predict(
+    f_fit,
+    na_1_data_1,
+    type = "survival",
+    eval_time = c(306, 455)
   )
   expect_equal(nrow(f_pred), nrow(na_1_data_1))
   expect_true(all(is.na(f_pred$.pred[[2]]$.pred_survival)))
 
-  expect_no_error(
-    f_pred <- predict(
-      f_fit,
-      na_1_data_0,
-      type = "survival",
-      eval_time = c(306, 455)
-    )
+  f_pred <- predict(
+    f_fit,
+    na_1_data_0,
+    type = "survival",
+    eval_time = c(306, 455)
   )
   expect_equal(nrow(f_pred), nrow(na_1_data_0))
   expect_true(all(is.na(f_pred$.pred[[1]]$.pred_survival)))
@@ -1033,9 +999,7 @@ test_that("linear_pred predictions without strata", {
   expect_equal(nrow(f_pred), nrow(lung2))
 
   # single observation
-  expect_no_error(
-    f_pred_1 <- predict(f_fit, lung2[1, ], type = "linear_pred")
-  )
+  f_pred_1 <- predict(f_fit, lung2[1, ], type = "linear_pred")
   expect_equal(nrow(f_pred_1), 1)
 
   # predict without the sign flip
@@ -1114,13 +1078,11 @@ test_that("linear_pred predictions with strata", {
   )
   cox_spec <- proportional_hazards(penalty = 0.123) |>
     set_engine("glmnet", cox.ties = "efron")
-  expect_no_error(
-    suppressWarnings(
-      f_fit <- fit(
-        cox_spec,
-        Surv(time, status) ~ age + ph.ecog + strata(sex),
-        data = lung2
-      )
+  suppressWarnings(
+    f_fit <- fit(
+      cox_spec,
+      Surv(time, status) ~ age + ph.ecog + strata(sex),
+      data = lung2
     )
   )
 
@@ -1138,9 +1100,7 @@ test_that("linear_pred predictions with strata", {
   expect_equal(nrow(f_pred), nrow(lung2))
 
   # single observation
-  expect_no_error(
-    f_pred_1 <- predict(f_fit, lung2[1, ], type = "linear_pred")
-  )
+  f_pred_1 <- predict(f_fit, lung2[1, ], type = "linear_pred")
   expect_equal(nrow(f_pred_1), 1)
 
   # predict without the sign flip
@@ -1272,19 +1232,15 @@ test_that("predictions with strata and dot in formula", {
   lung2 <- lung2[complete.cases(lung2), ]
 
   # formula method
-  expect_no_error(
-    f_fit <- fit(
-      cox_spec,
-      Surv(time, status) ~ . - sex + strata(sex),
-      data = lung2
-    )
+  f_fit <- fit(
+    cox_spec,
+    Surv(time, status) ~ . - sex + strata(sex),
+    data = lung2
   )
-  expect_no_error(
-    f_fit_2 <- fit(
-      cox_spec,
-      Surv(time, status) ~ ph.ecog + age + strata(sex),
-      data = lung2
-    )
+  f_fit_2 <- fit(
+    cox_spec,
+    Surv(time, status) ~ ph.ecog + age + strata(sex),
+    data = lung2
   )
   expect_no_error(
     predict(f_fit, lung2, type = "linear_pred")

--- a/tests/testthat/test-proportional_hazards-survival.R
+++ b/tests/testthat/test-proportional_hazards-survival.R
@@ -8,9 +8,7 @@ test_that("model object", {
 
   # formula method
   cox_spec <- proportional_hazards() |> set_engine("survival")
-  expect_no_error(
-    f_fit <- fit(cox_spec, Surv(time, status) ~ age + sex, data = lung)
-  )
+  f_fit <- fit(cox_spec, Surv(time, status) ~ age + sex, data = lung)
 
   # Removing `model` element from f_fit and `call` from both
   expect_equal(f_fit$fit[-c(16, 21)], exp_f_fit[-20], ignore_formula_env = TRUE)
@@ -23,9 +21,7 @@ test_that("time predictions without strata", {
   exp_f_fit <- coxph(Surv(time, status) ~ age + sex, data = lung, x = TRUE)
 
   # formula method
-  expect_no_error(
-    f_fit <- fit(cox_spec, Surv(time, status) ~ age + sex, data = lung)
-  )
+  f_fit <- fit(cox_spec, Surv(time, status) ~ age + sex, data = lung)
   f_pred <- predict(f_fit, lung, type = "time")
   tabs <- summary(survfit(exp_f_fit, lung, na.action = na.pass))$table
   colnames(tabs) <- gsub("[[:punct:]]", "", colnames(tabs))
@@ -37,7 +33,7 @@ test_that("time predictions without strata", {
   expect_equal(nrow(f_pred), nrow(lung))
 
   # single observation
-  expect_no_error(f_pred_1 <- predict(f_fit, lung[1, ], type = "time"))
+  f_pred_1 <- predict(f_fit, lung[1, ], type = "time")
   expect_equal(nrow(f_pred_1), 1)
 })
 
@@ -50,12 +46,10 @@ test_that("time predictions with strata", {
   )
 
   # formula method
-  expect_no_error(
-    f_fit <- fit(
-      cox_spec,
-      Surv(time, status) ~ age + sex + strata(inst),
-      data = lung
-    )
+  f_fit <- fit(
+    cox_spec,
+    Surv(time, status) ~ age + sex + strata(inst),
+    data = lung
   )
   new_data_3 <- lung[1:3, ]
   f_pred <- predict(f_fit, new_data_3, type = "time")
@@ -69,18 +63,16 @@ test_that("time predictions with strata", {
   expect_equal(nrow(f_pred), nrow(new_data_3))
 
   # single observation
-  expect_no_error(f_pred_1 <- predict(f_fit, lung[1, ], type = "time"))
+  f_pred_1 <- predict(f_fit, lung[1, ], type = "time")
   expect_equal(nrow(f_pred_1), 1)
 })
 
 test_that("time predictions with NA", {
   cox_spec <- proportional_hazards() |> set_engine("survival")
-  expect_no_error(
-    f_fit <- fit(
-      cox_spec,
-      Surv(time, status) ~ age + strata(ph.ecog),
-      data = lung
-    )
+  f_fit <- fit(
+    cox_spec,
+    Surv(time, status) ~ age + strata(ph.ecog),
+    data = lung
   )
 
   # survfit.coxph() is not type-stable,
@@ -94,39 +86,27 @@ test_that("time predictions with NA", {
   na_1_data_0 <- lung[14, ]
 
   # survival time
-  expect_no_error(
-    f_pred <- predict(f_fit, na_x_data_x, type = "time")
-  )
+  f_pred <- predict(f_fit, na_x_data_x, type = "time")
   expect_equal(nrow(f_pred), nrow(na_x_data_x))
   expect_equal(which(is.na(f_pred$.pred_time)), c(2, 4))
 
-  expect_no_error(
-    f_pred <- predict(f_fit, na_x_data_1, type = "time")
-  )
+  f_pred <- predict(f_fit, na_x_data_1, type = "time")
   expect_equal(nrow(f_pred), nrow(na_x_data_1))
   expect_equal(which(is.na(f_pred$.pred_time)), c(2, 3))
 
-  expect_no_error(
-    f_pred <- predict(f_fit, na_x_data_0, type = "time")
-  )
+  f_pred <- predict(f_fit, na_x_data_0, type = "time")
   expect_equal(nrow(f_pred), nrow(na_x_data_0))
   expect_equal(which(is.na(f_pred$.pred_time)), 1:2)
 
-  expect_no_error(
-    f_pred <- predict(f_fit, na_1_data_x, type = "time")
-  )
+  f_pred <- predict(f_fit, na_1_data_x, type = "time")
   expect_equal(nrow(f_pred), nrow(na_1_data_x))
   expect_equal(which(is.na(f_pred$.pred_time)), 2)
 
-  expect_no_error(
-    f_pred <- predict(f_fit, na_1_data_1, type = "time")
-  )
+  f_pred <- predict(f_fit, na_1_data_1, type = "time")
   expect_equal(nrow(f_pred), nrow(na_1_data_1))
   expect_equal(which(is.na(f_pred$.pred_time)), 2)
 
-  expect_no_error(
-    f_pred <- predict(f_fit, na_1_data_0, type = "time")
-  )
+  f_pred <- predict(f_fit, na_1_data_0, type = "time")
   expect_equal(nrow(f_pred), nrow(na_1_data_0))
   expect_true(is.na(f_pred$.pred_time))
 })
@@ -163,9 +143,7 @@ test_that("survival predictions without strata", {
   exp_f_fit <- coxph(Surv(time, status) ~ age + sex, data = lung, x = TRUE)
 
   # formula method
-  expect_no_error(
-    f_fit <- fit(cox_spec, Surv(time, status) ~ age + sex, data = lung)
-  )
+  f_fit <- fit(cox_spec, Surv(time, status) ~ age + sex, data = lung)
   # move snapshot test below back here after parsnip v1.3.0 release
 
   # Test at observed event times since we use the step function and pec does not
@@ -197,13 +175,11 @@ test_that("survival predictions without strata", {
   )
 
   # single observation
-  expect_no_error(
-    f_pred_1 <- predict(
-      f_fit,
-      lung[1, ],
-      type = "survival",
-      eval_time = c(306, 455)
-    )
+  f_pred_1 <- predict(
+    f_fit,
+    lung[1, ],
+    type = "survival",
+    eval_time = c(306, 455)
   )
   expect_equal(nrow(f_pred_1), 1)
 })
@@ -280,13 +256,11 @@ test_that("survival predictions with strata", {
   )
 
   # single observation
-  expect_no_error(
-    f_pred_1 <- predict(
-      f_fit,
-      bladder[1, ],
-      type = "survival",
-      eval_time = c(10, 20)
-    )
+  f_pred_1 <- predict(
+    f_fit,
+    bladder[1, ],
+    type = "survival",
+    eval_time = c(10, 20)
   )
   expect_equal(nrow(f_pred_1), 1)
 
@@ -299,12 +273,10 @@ test_that("survival predictions with strata", {
 
 test_that("survival prediction with NA", {
   cox_spec <- proportional_hazards() |> set_engine("survival")
-  expect_no_error(
-    f_fit <- fit(
-      cox_spec,
-      Surv(time, status) ~ age + strata(ph.ecog),
-      data = lung
-    )
+  f_fit <- fit(
+    cox_spec,
+    Surv(time, status) ~ age + strata(ph.ecog),
+    data = lung
   )
 
   # survfit.coxph() is not type-stable,
@@ -318,71 +290,59 @@ test_that("survival prediction with NA", {
   na_1_data_0 <- lung[14, ]
 
   # survival probabilities
-  expect_no_error(
-    f_pred <- predict(
-      f_fit,
-      na_x_data_x,
-      type = "survival",
-      eval_time = c(306, 455)
-    )
+  f_pred <- predict(
+    f_fit,
+    na_x_data_x,
+    type = "survival",
+    eval_time = c(306, 455)
   )
   expect_equal(nrow(f_pred), nrow(na_x_data_x))
   expect_true(all(is.na(f_pred$.pred[[2]]$.pred_survival)))
   expect_true(all(is.na(f_pred$.pred[[4]]$.pred_survival)))
 
-  expect_no_error(
-    f_pred <- predict(
-      f_fit,
-      na_x_data_1,
-      type = "survival",
-      eval_time = c(306, 455)
-    )
+  f_pred <- predict(
+    f_fit,
+    na_x_data_1,
+    type = "survival",
+    eval_time = c(306, 455)
   )
   expect_equal(nrow(f_pred), nrow(na_x_data_1))
   expect_true(all(is.na(f_pred$.pred[[2]]$.pred_survival)))
   expect_true(all(is.na(f_pred$.pred[[3]]$.pred_survival)))
 
-  expect_no_error(
-    f_pred <- predict(
-      f_fit,
-      na_x_data_0,
-      type = "survival",
-      eval_time = c(306, 455)
-    )
+  f_pred <- predict(
+    f_fit,
+    na_x_data_0,
+    type = "survival",
+    eval_time = c(306, 455)
   )
   expect_equal(nrow(f_pred), nrow(na_x_data_0))
   expect_true(all(is.na(f_pred$.pred[[1]]$.pred_survival)))
   expect_true(all(is.na(f_pred$.pred[[2]]$.pred_survival)))
 
-  expect_no_error(
-    f_pred <- predict(
-      f_fit,
-      na_1_data_x,
-      type = "survival",
-      eval_time = c(306, 455)
-    )
+  f_pred <- predict(
+    f_fit,
+    na_1_data_x,
+    type = "survival",
+    eval_time = c(306, 455)
   )
   expect_equal(nrow(f_pred), nrow(na_1_data_x))
   expect_true(all(is.na(f_pred$.pred[[2]]$.pred_survival)))
 
-  expect_no_error(
-    f_pred <- predict(
-      f_fit,
-      na_1_data_1,
-      type = "survival",
-      eval_time = c(306, 455)
-    )
+  f_pred <- predict(
+    f_fit,
+    na_1_data_1,
+    type = "survival",
+    eval_time = c(306, 455)
   )
   expect_equal(nrow(f_pred), nrow(na_1_data_1))
   expect_true(all(is.na(f_pred$.pred[[2]]$.pred_survival)))
 
-  expect_no_error(
-    f_pred <- predict(
-      f_fit,
-      na_1_data_0,
-      type = "survival",
-      eval_time = c(306, 455)
-    )
+  f_pred <- predict(
+    f_fit,
+    na_1_data_0,
+    type = "survival",
+    eval_time = c(306, 455)
   )
   expect_equal(nrow(f_pred), nrow(na_1_data_0))
   expect_true(all(is.na(f_pred$.pred[[1]]$.pred_survival)))
@@ -496,9 +456,7 @@ test_that("linear_pred predictions without strata", {
   exp_f_fit <- coxph(Surv(time, status) ~ age + sex, data = lung, x = TRUE)
 
   # formula method
-  expect_no_error(
-    f_fit <- fit(cox_spec, Surv(time, status) ~ age + sex, data = lung)
-  )
+  f_fit <- fit(cox_spec, Surv(time, status) ~ age + sex, data = lung)
   f_pred <- predict(f_fit, lung, type = "linear_pred")
   exp_f_pred <- -unname(predict(exp_f_fit, newdata = lung, reference = "zero"))
 
@@ -508,7 +466,7 @@ test_that("linear_pred predictions without strata", {
   expect_equal(nrow(f_pred), nrow(lung))
 
   # single observation
-  expect_no_error(f_pred_1 <- predict(f_fit, lung[1, ], type = "linear_pred"))
+  f_pred_1 <- predict(f_fit, lung[1, ], type = "linear_pred")
   expect_equal(nrow(f_pred_1), 1)
 
   # don't flip the sign
@@ -530,10 +488,8 @@ test_that("linear_pred predictions with strata", {
   )
 
   # formula method
-  expect_no_error(
-    f_fit <- cox_spec |>
-      fit(Surv(time, status) ~ age + sex + strata(inst), data = lung)
-  )
+  f_fit <- cox_spec |>
+    fit(Surv(time, status) ~ age + sex + strata(inst), data = lung)
   f_pred <- predict(f_fit, lung, type = "linear_pred")
   exp_f_pred <- -unname(predict(exp_f_fit, newdata = lung, reference = "zero"))
 
@@ -543,7 +499,7 @@ test_that("linear_pred predictions with strata", {
   expect_equal(nrow(f_pred), nrow(lung))
 
   # single observation
-  expect_no_error(f_pred_1 <- predict(f_fit, lung[1, ], type = "linear_pred"))
+  f_pred_1 <- predict(f_fit, lung[1, ], type = "linear_pred")
   expect_equal(nrow(f_pred_1), 1)
 
   # don't flip the sign
@@ -566,15 +522,11 @@ test_that("predictions with strata and dot in formula", {
   cox_spec <- proportional_hazards() |> set_engine("survival")
 
   # formula method
-  expect_no_error(
-    f_fit <- fit(cox_spec, Surv(time, status) ~ . + strata(sex), data = lung2)
-  )
-  expect_no_error(
-    f_fit_2 <- fit(
-      cox_spec,
-      Surv(time, status) ~ age + strata(sex),
-      data = lung2
-    )
+  f_fit <- fit(cox_spec, Surv(time, status) ~ . + strata(sex), data = lung2)
+  f_fit_2 <- fit(
+    cox_spec,
+    Surv(time, status) ~ age + strata(sex),
+    data = lung2
   )
   expect_no_error(
     {

--- a/tests/testthat/test-rand_forest-aorsf.R
+++ b/tests/testthat/test-rand_forest-aorsf.R
@@ -17,12 +17,10 @@ test_that("model object", {
     set_mode("censored regression")
 
   set.seed(1234)
-  expect_no_error(
-    f_fit <- fit(
-      mod_spec,
-      Surv(time, status) ~ age + ph.ecog,
-      data = lung_orsf
-    )
+  f_fit <- fit(
+    mod_spec,
+    Surv(time, status) ~ age + ph.ecog,
+    data = lung_orsf
   )
 
   expect_equal(
@@ -307,12 +305,10 @@ test_that("can handle case weights", {
 
   dat <- make_cens_wts()
 
-  expect_no_error(
-    wt_fit <- rand_forest() |>
-      set_engine("aorsf") |>
-      set_mode("censored regression") |>
-      fit(Surv(time, event) ~ ., data = dat$full, case_weights = dat$wts)
-  )
+  wt_fit <- rand_forest() |>
+    set_engine("aorsf") |>
+    set_mode("censored regression") |>
+    fit(Surv(time, event) ~ ., data = dat$full, case_weights = dat$wts)
 
   if (utils::packageVersion("aorsf") >= "0.1.2") {
     fit_weights <- wt_fit$fit$weights

--- a/tests/testthat/test-rand_forest-partykit.R
+++ b/tests/testthat/test-rand_forest-partykit.R
@@ -15,9 +15,7 @@ test_that("model object", {
     set_engine("partykit") |>
     set_mode("censored regression")
   set.seed(1234)
-  expect_no_error(
-    f_fit <- fit(mod_spec, Surv(time, status) ~ age + ph.ecog, data = lung)
-  )
+  f_fit <- fit(mod_spec, Surv(time, status) ~ age + ph.ecog, data = lung)
 
   # remove `call` from comparison
   f_fit$fit$info$call <- NULL

--- a/tests/testthat/test-rand_forest-randomForestSRC.R
+++ b/tests/testthat/test-rand_forest-randomForestSRC.R
@@ -398,12 +398,10 @@ test_that("can handle case weights", {
   dat <- make_cens_wts()
 
   set.seed(1)
-  expect_no_error(
-    wt_fit <- rand_forest(trees = 50) |>
-      set_engine("randomForestSRC") |>
-      set_mode("censored regression") |>
-      fit(Surv(time, event) ~ ., data = dat$full, case_weights = dat$wts)
-  )
+  wt_fit <- rand_forest(trees = 50) |>
+    set_engine("randomForestSRC") |>
+    set_mode("censored regression") |>
+    fit(Surv(time, event) ~ ., data = dat$full, case_weights = dat$wts)
 
   set.seed(1)
   unwt_fit <- rand_forest(trees = 50) |>

--- a/tests/testthat/test-rand_forest-ranger.R
+++ b/tests/testthat/test-rand_forest-ranger.R
@@ -29,12 +29,10 @@ test_that("model object", {
     set_engine("ranger", seed = 1) |>
     set_mode("censored regression")
 
-  expect_no_error(
-    f_fit <- fit(
-      mod_spec,
-      Surv(time, status) ~ age + ph.ecog,
-      data = lung_ranger
-    )
+  f_fit <- fit(
+    mod_spec,
+    Surv(time, status) ~ age + ph.ecog,
+    data = lung_ranger
   )
 
   expect_s3_class(f_fit$fit, "ranger")
@@ -328,12 +326,10 @@ test_that("can handle case weights", {
 
   dat <- make_cens_wts()
 
-  expect_no_error(
-    wt_fit <- rand_forest(trees = 3) |>
-      set_engine("ranger", seed = 1) |>
-      set_mode("censored regression") |>
-      fit(Surv(time, event) ~ ., data = dat$full, case_weights = dat$wts)
-  )
+  wt_fit <- rand_forest(trees = 3) |>
+    set_engine("ranger", seed = 1) |>
+    set_mode("censored regression") |>
+    fit(Surv(time, event) ~ ., data = dat$full, case_weights = dat$wts)
 
   unwt_fit <- rand_forest(trees = 3) |>
     set_engine("ranger", seed = 1) |>

--- a/tests/testthat/test-survival_reg-flexsurvspline.R
+++ b/tests/testthat/test-survival_reg-flexsurvspline.R
@@ -483,13 +483,11 @@ test_that("can handle case weights", {
   wts <- runif(nrow(lung))
   wts <- importance_weights(wts)
 
-  expect_no_error(
-    wt_fit <- survival_reg() |>
-      set_engine("flexsurvspline", k = 1) |>
-      set_mode("censored regression") |>
-      fit(Surv(time, status) ~ age + sex, data = lung, case_weights = wts) |>
-      suppressWarnings()
-  )
+  wt_fit <- survival_reg() |>
+    set_engine("flexsurvspline", k = 1) |>
+    set_mode("censored regression") |>
+    fit(Surv(time, status) ~ age + sex, data = lung, case_weights = wts) |>
+    suppressWarnings()
 
   unwt_fit <-
     survival_reg() |>


### PR DESCRIPTION
We don't need a `expect_no_error()` around something that we use for other expectations afterwards.

If we do only want to test that there is no error, we don't need to assign it to an object.