### PR TITLE
Return `NA` for predictions with missing strata variable for `survival_reg()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 * The `survival_prob_*()` and `hazard_*()` helpers now validate their inputs and return more informative error messages when given an unusable `object`, `new_data`, or `eval_time` (#271).
 
+* `survival_reg()` with the `"survival"` engine and `strata()` terms now returns `NA` survival and hazard predictions for new data rows with a missing value in a stratification variable, instead of silently using another stratum's scale (#383).
+
 
 # censored 0.3.4
 

--- a/R/survival_reg-survival.R
+++ b/R/survival_reg-survival.R
@@ -57,17 +57,11 @@ compute_strata <- function(object, new_data) {
 
 deparse_survreg_strata <- function(object, new_data) {
   new_new_data <- compute_strata(object, new_data)
-  lvls <- levels(new_new_data$.strata)
 
-  # link this to scales vector
-  scales <- tibble(.strata = names(object$scale), .scale = unname(object$scale))
-  scales$.strata <- factor(scales$.strata, levels = lvls)
-
-  # return a vector with appropriate estimates for new data
-  new_new_data$.row <- seq_len(nrow(new_new_data))
-  new_new_data <- dplyr::left_join(new_new_data, scales, by = ".strata")
-  new_new_data <- new_new_data[order(new_new_data$.row), ]
-  new_new_data$.scale
+  # Match each row's stratum to its scale by name. A missing strata value
+  # (or one not seen when fitting) matches no scale and so yields `NA`.
+  strata <- as.character(new_new_data$.strata)
+  unname(object$scale[strata])
 }
 
 survreg_survival <- function(location, object, scale, eval_time, ...) {

--- a/tests/testthat/test-survival_reg-survival.R
+++ b/tests/testthat/test-survival_reg-survival.R
@@ -226,6 +226,151 @@ test_that("survival hazard prediction", {
   expect_identical(nrow(f_pred_1), 1L)
 })
 
+# prediction with strata --------------------------------------------------
+
+test_that("survival probabilities with strata match a hand computation", {
+  f_fit <- survival_reg() |>
+    set_engine("survival") |>
+    fit(Surv(time, status) ~ age + strata(sex), data = lung)
+  engine_fit <- extract_fit_engine(f_fit)
+
+  # strata give one scale per stratum, exercising the multi-scale branch
+  expect_named(engine_fit$scale, c("sex=1", "sex=2"))
+
+  new_data <- lung[c(1, 7, 20), ]
+  # both strata represented
+  expect_equal(new_data$sex, c(1, 2, 1))
+
+  eval_time <- c(100, 500)
+  pred <- predict(f_fit, new_data, type = "survival", eval_time = eval_time)
+  lp <- predict(engine_fit, new_data, type = "lp")
+
+  # match each row to its stratum's scale by hand
+  expect_equal(
+    pred$.pred[[1]]$.pred_survival,
+    1 -
+      survival::psurvreg(
+        eval_time,
+        lp[1],
+        distribution = engine_fit$dist,
+        scale = engine_fit$scale[["sex=1"]]
+      )
+  )
+  expect_equal(
+    pred$.pred[[2]]$.pred_survival,
+    1 -
+      survival::psurvreg(
+        eval_time,
+        lp[2],
+        distribution = engine_fit$dist,
+        scale = engine_fit$scale[["sex=2"]]
+      )
+  )
+  expect_equal(
+    pred$.pred[[3]]$.pred_survival,
+    1 -
+      survival::psurvreg(
+        eval_time,
+        lp[3],
+        distribution = engine_fit$dist,
+        scale = engine_fit$scale[["sex=1"]]
+      )
+  )
+})
+
+test_that("NA in the strata variable gives NA predictions with rows preserved", {
+  f_fit <- survival_reg() |>
+    set_engine("survival") |>
+    fit(Surv(time, status) ~ age + strata(sex), data = lung)
+
+  eval_time <- c(100, 500)
+  na_pred <- rep(NA_real_, length(eval_time))
+
+  # A missing strata value must predict NA regardless of which strata the
+  # other rows belong to (see https://github.com/tidymodels/censored/issues/383).
+  na_and_sex1 <- lung[c(1, 2), ]
+  na_and_sex1$sex[1] <- NA
+  na_and_sex2 <- lung[c(1, 7), ]
+  na_and_sex2$sex[1] <- NA
+
+  pred_1 <- predict(
+    f_fit,
+    na_and_sex1,
+    type = "survival",
+    eval_time = eval_time
+  )
+  pred_2 <- predict(
+    f_fit,
+    na_and_sex2,
+    type = "survival",
+    eval_time = eval_time
+  )
+
+  expect_equal(nrow(pred_1), 2)
+  expect_equal(nrow(pred_2), 2)
+  expect_equal(pred_1$.pred[[1]]$.pred_survival, na_pred)
+  expect_equal(pred_2$.pred[[1]]$.pred_survival, na_pred)
+})
+
+test_that("hazard predictions with strata match a hand computation", {
+  f_fit <- survival_reg() |>
+    set_engine("survival") |>
+    fit(Surv(time, status) ~ age + strata(sex), data = lung)
+  engine_fit <- extract_fit_engine(f_fit)
+
+  new_data <- lung[c(1, 7, 20), ]
+  eval_time <- c(100, 500)
+  pred <- predict(f_fit, new_data, type = "hazard", eval_time = eval_time)
+  lp <- predict(engine_fit, new_data, type = "lp")
+
+  hand_hazard <- function(lp_i, scale_i) {
+    survival::dsurvreg(
+      eval_time,
+      lp_i,
+      scale_i,
+      distribution = engine_fit$dist
+    ) /
+      (1 -
+        survival::psurvreg(
+          eval_time,
+          lp_i,
+          distribution = engine_fit$dist,
+          scale = scale_i
+        ))
+  }
+
+  expect_equal(
+    pred$.pred[[1]]$.pred_hazard,
+    hand_hazard(lp[1], engine_fit$scale[["sex=1"]])
+  )
+  expect_equal(
+    pred$.pred[[2]]$.pred_hazard,
+    hand_hazard(lp[2], engine_fit$scale[["sex=2"]])
+  )
+  expect_equal(
+    pred$.pred[[3]]$.pred_hazard,
+    hand_hazard(lp[3], engine_fit$scale[["sex=1"]])
+  )
+})
+
+test_that("survival_prob_survreg() and hazard_survreg() work on stratified fits", {
+  f_fit <- survival_reg() |>
+    set_engine("survival") |>
+    fit(Surv(time, status) ~ age + strata(sex), data = lung)
+
+  new_data <- lung[c(1, 7, 20), ]
+  eval_time <- c(100, 500)
+
+  expect_equal(
+    survival_prob_survreg(f_fit, new_data, eval_time = eval_time),
+    predict(f_fit, new_data, type = "survival", eval_time = eval_time)
+  )
+  expect_equal(
+    hazard_survreg(f_fit, new_data, eval_time = eval_time),
+    predict(f_fit, new_data, type = "hazard", eval_time = eval_time)
+  )
+})
+
 # fit via matrix interface ------------------------------------------------
 
 test_that("`fix_xy()` works", {


### PR DESCRIPTION
closes #383 

and increases test coverage for fitting stratified `survival_reg()` with the `survival` engine