### PR TITLE
Disable case weights for mboost

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # censored (development version)
 
+* `boost_tree()` with the `"mboost"` engine no longer accepts case weights because mboost cannot predict from a weighted fit (#363).
+
 * `rand_forest()` now supports the `"censored regression"` mode with a new `"ranger"` engine, fitting a survival random forest via `ranger::ranger()` (#131).
 
 * `rand_forest()` now supports the `"randomForestSRC"` engine for censored regression, fitting a survival random forest via `randomForestSRC::rfsrc()` (#130).

--- a/R/boost_tree-data.R
+++ b/R/boost_tree-data.R
@@ -79,7 +79,9 @@ make_boost_tree_mboost <- function() {
     mode = "censored regression",
     value = list(
       interface = "formula",
-      protect = c("formula", "data", "weights"),
+      # case weights are not enabled because mboost cannot predict from a
+      # weighted fit (#363)
+      protect = c("formula", "data"),
       func = c(pkg = "censored", fun = "blackboost_train"),
       defaults = list(family = expr(mboost::CoxPH()))
     )


### PR DESCRIPTION
closes #363

mboost can fit with weights but not predict, so we are removing the case weights integration via the parsnip frame work. We're not removing support for the weights from the fit wrapper just yet because hopefully we can get prediction with a weighted fit from mboost in the future.