### PR TITLE
Extend tests on registration and tuning parameters across engines

### DIFF
--- a/tests/testthat/test-bag_tree-rpart.R
+++ b/tests/testthat/test-bag_tree-rpart.R
@@ -1,5 +1,24 @@
 library(testthat)
 
+# registration ------------------------------------------------------------
+
+test_that("engine is registered and translate() works", {
+  skip_if_not_installed("ipred")
+
+  engines <- parsnip::show_engines("bag_tree")
+  censored_engines <- engines$engine[engines$mode == "censored regression"]
+  expect_in("rpart", censored_engines)
+
+  spec <- bag_tree() |>
+    set_engine("rpart") |>
+    set_mode("censored regression")
+
+  translated <- translate(spec)
+  expect_equal(translated$method$fit$func[["fun"]], "bagging")
+})
+
+# fit ---------------------------------------------------------------------
+
 test_that("model object", {
   skip_if_not_installed("ipred")
 

--- a/tests/testthat/test-boost_tree-mboost.R
+++ b/tests/testthat/test-boost_tree-mboost.R
@@ -1,5 +1,29 @@
 library(testthat)
 
+# registration ------------------------------------------------------------
+
+test_that("engine is registered and translate() works", {
+  skip_if_not_installed("mboost")
+
+  engines <- parsnip::show_engines("boost_tree")
+  censored_engines <- engines$engine[engines$mode == "censored regression"]
+  expect_in("mboost", censored_engines)
+
+  spec <- boost_tree(trees = 100, min_n = 5, tree_depth = 3) |>
+    set_engine("mboost") |>
+    set_mode("censored regression")
+
+  translated <- translate(spec)
+  expect_equal(translated$method$fit$func[["fun"]], "blackboost_train")
+  expect_in(
+    c("mstop", "minsplit", "maxdepth"),
+    names(translated$method$fit$args)
+  )
+  expect_equal(rlang::eval_tidy(translated$method$fit$args$mstop), 100)
+})
+
+# fit ---------------------------------------------------------------------
+
 test_that("model object", {
   skip_if_not_installed("mboost")
 
@@ -901,6 +925,28 @@ test_that("multi_predict() errors informatively on bad input", {
       type = "time",
       trees = c(1.5, 50)
     )
+  )
+})
+
+# tuning ------------------------------------------------------------------
+
+test_that("tuning parameters are inherited", {
+  skip_if_not_installed("mboost")
+
+  spec <- boost_tree(
+    mtry = tune(),
+    trees = tune(),
+    min_n = tune(),
+    tree_depth = tune(),
+    loss_reduction = tune()
+  ) |>
+    set_engine("mboost") |>
+    set_mode("censored regression")
+
+  params <- hardhat::extract_parameter_set_dials(spec)
+  expect_setequal(
+    params$name,
+    c("mtry", "trees", "min_n", "tree_depth", "loss_reduction")
   )
 })
 

--- a/tests/testthat/test-decision_tree-partykit.R
+++ b/tests/testthat/test-decision_tree-partykit.R
@@ -1,5 +1,25 @@
 library(testthat)
 
+# registration ------------------------------------------------------------
+
+test_that("engine is registered and translate() works", {
+  skip_if_not_installed("partykit")
+
+  engines <- parsnip::show_engines("decision_tree")
+  censored_engines <- engines$engine[engines$mode == "censored regression"]
+  expect_in("partykit", censored_engines)
+
+  spec <- decision_tree(tree_depth = 20, min_n = 5) |>
+    set_engine("partykit") |>
+    set_mode("censored regression")
+
+  translated <- translate(spec)
+  expect_equal(translated$method$fit$func[["fun"]], "ctree_train")
+  expect_in(c("maxdepth", "minsplit"), names(translated$method$fit$args))
+})
+
+# fit ---------------------------------------------------------------------
+
 test_that("model object", {
   skip_if_not_installed("partykit")
   skip_if_not_installed("coin")
@@ -193,6 +213,27 @@ test_that("`fix_xy()` works", {
     eval_time = c(100, 200)
   )
   expect_equal(f_pred_survival, xy_pred_survival)
+})
+
+# tuning ------------------------------------------------------------------
+
+test_that("tuning parameters are inherited", {
+  skip_if_not_installed("partykit")
+
+  spec <- decision_tree(tree_depth = tune(), min_n = tune()) |>
+    set_engine(
+      "partykit",
+      mincriterion = tune(),
+      teststat = tune(),
+      testtype = tune()
+    ) |>
+    set_mode("censored regression")
+
+  params <- hardhat::extract_parameter_set_dials(spec)
+  expect_setequal(
+    params$name,
+    c("tree_depth", "min_n", "mincriterion", "teststat", "testtype")
+  )
 })
 
 # case weights ------------------------------------------------------------

--- a/tests/testthat/test-decision_tree-rpart.R
+++ b/tests/testthat/test-decision_tree-rpart.R
@@ -1,5 +1,25 @@
 library(testthat)
 
+# registration ------------------------------------------------------------
+
+test_that("engine is registered and translate() works", {
+  skip_if_not_installed("pec")
+
+  engines <- parsnip::show_engines("decision_tree")
+  censored_engines <- engines$engine[engines$mode == "censored regression"]
+  expect_in("rpart", censored_engines)
+
+  spec <- decision_tree(tree_depth = 20) |>
+    set_engine("rpart") |>
+    set_mode("censored regression")
+
+  translated <- translate(spec)
+  expect_equal(translated$method$fit$func[["fun"]], "pecRpart")
+  expect_equal(rlang::eval_tidy(translated$method$fit$args$maxdepth), 20)
+})
+
+# fit ---------------------------------------------------------------------
+
 test_that("model object", {
   skip_if_not_installed("pec")
 
@@ -315,6 +335,23 @@ test_that("survival_prob_pecRpart() accepts eval_time values that it can handle"
       eval_time = c(100, 100, 200)
     )
   )
+})
+
+# tuning ------------------------------------------------------------------
+
+test_that("tuning parameters are inherited", {
+  skip_if_not_installed("pec")
+
+  spec <- decision_tree(
+    cost_complexity = tune(),
+    tree_depth = tune(),
+    min_n = tune()
+  ) |>
+    set_engine("rpart") |>
+    set_mode("censored regression")
+
+  params <- hardhat::extract_parameter_set_dials(spec)
+  expect_setequal(params$name, c("cost_complexity", "tree_depth", "min_n"))
 })
 
 # case weights ------------------------------------------------------------

--- a/tests/testthat/test-null_model-survival.R
+++ b/tests/testthat/test-null_model-survival.R
@@ -1,6 +1,23 @@
 library(testthat)
 library(survival)
 
+# registration ------------------------------------------------------------
+
+test_that("engine is registered and translate() works", {
+  engines <- parsnip::show_engines("null_model")
+  censored_engines <- engines$engine[engines$mode == "censored regression"]
+  expect_in("survival", censored_engines)
+
+  spec <- null_model() |>
+    set_engine("survival") |>
+    set_mode("censored regression")
+
+  translated <- translate(spec)
+  expect_equal(translated$method$fit$func[["fun"]], "survfit_null")
+})
+
+# fit ---------------------------------------------------------------------
+
 test_that("model object ignores predictors", {
   spec <- null_model() |>
     set_engine("survival") |>

--- a/tests/testthat/test-proportional_hazards-glmnet.R
+++ b/tests/testthat/test-proportional_hazards-glmnet.R
@@ -2,6 +2,27 @@ library(testthat)
 skip_if_not_installed("glmnet")
 suppressPackageStartupMessages(library(glmnet))
 
+# registration ------------------------------------------------------------
+
+test_that("engine is registered and translate() works", {
+  skip_if_not_installed("glmnet")
+
+  engines <- parsnip::show_engines("proportional_hazards")
+  censored_engines <- engines$engine[engines$mode == "censored regression"]
+  expect_in("glmnet", censored_engines)
+
+  spec <- proportional_hazards(penalty = 0.1, mixture = 0.5) |>
+    set_engine("glmnet") |>
+    set_mode("censored regression")
+
+  translated <- translate(spec)
+  expect_equal(translated$method$fit$func[["fun"]], "coxnet_train")
+  expect_in("alpha", names(translated$method$fit$args))
+  expect_equal(rlang::eval_tidy(translated$method$fit$args$alpha), 0.5)
+})
+
+# fit ---------------------------------------------------------------------
+
 test_that("model object", {
   lung2 <- lung[-14, ]
   exp_f_fit <- glmnet(
@@ -1990,6 +2011,19 @@ test_that("survival_prob_coxnet() warns about deprecated `time` argument", {
     pred_deprecated,
     survival_prob_coxnet(mod, new_data = new_data, eval_time = 100)
   )
+})
+
+# tuning ------------------------------------------------------------------
+
+test_that("tuning parameters are inherited", {
+  skip_if_not_installed("glmnet")
+
+  spec <- proportional_hazards(penalty = tune(), mixture = tune()) |>
+    set_engine("glmnet") |>
+    set_mode("censored regression")
+
+  params <- hardhat::extract_parameter_set_dials(spec)
+  expect_setequal(params$name, c("penalty", "mixture"))
 })
 
 # case weights ------------------------------------------------------------

--- a/tests/testthat/test-proportional_hazards-survival.R
+++ b/tests/testthat/test-proportional_hazards-survival.R
@@ -1,5 +1,23 @@
 library(testthat)
 
+# registration ------------------------------------------------------------
+
+test_that("engine is registered and translate() works", {
+  engines <- parsnip::show_engines("proportional_hazards")
+  censored_engines <- engines$engine[engines$mode == "censored regression"]
+  expect_in("survival", censored_engines)
+
+  spec <- proportional_hazards() |>
+    set_engine("survival") |>
+    set_mode("censored regression")
+
+  translated <- translate(spec)
+  expect_equal(translated$method$fit$func[["fun"]], "coxph")
+  expect_equal(translated$method$fit$defaults$model, TRUE)
+})
+
+# fit ---------------------------------------------------------------------
+
 # survival has some issues where missing predictor value get ommited despite
 # na.action = na.exclude. See https://github.com/therneau/survival/issues/137
 

--- a/tests/testthat/test-rand_forest-aorsf.R
+++ b/tests/testthat/test-rand_forest-aorsf.R
@@ -1,5 +1,26 @@
 library(testthat)
 
+# registration ------------------------------------------------------------
+
+test_that("engine is registered and translate() works", {
+  skip_if_not_installed("aorsf")
+
+  engines <- parsnip::show_engines("rand_forest")
+  censored_engines <- engines$engine[engines$mode == "censored regression"]
+  expect_in("aorsf", censored_engines)
+
+  spec <- rand_forest(trees = 100, min_n = 5) |>
+    set_engine("aorsf") |>
+    set_mode("censored regression")
+
+  translated <- translate(spec)
+  expect_equal(translated$method$fit$func[["fun"]], "orsf")
+  expect_in(c("n_tree", "leaf_min_obs"), names(translated$method$fit$args))
+  expect_equal(rlang::eval_tidy(translated$method$fit$args$n_tree), 100)
+})
+
+# fit ---------------------------------------------------------------------
+
 test_that("model object", {
   skip_if_not_installed("aorsf")
 
@@ -297,6 +318,19 @@ test_that("`fix_xy()` works", {
   expect_equal(f_pred_survival, xy_pred_survival)
 })
 
+
+# tuning ------------------------------------------------------------------
+
+test_that("tuning parameters are inherited", {
+  skip_if_not_installed("aorsf")
+
+  spec <- rand_forest(mtry = tune(), trees = tune(), min_n = tune()) |>
+    set_engine("aorsf", split_min_stat = tune()) |>
+    set_mode("censored regression")
+
+  params <- hardhat::extract_parameter_set_dials(spec)
+  expect_setequal(params$name, c("mtry", "trees", "min_n", "split_min_stat"))
+})
 
 # case weights ------------------------------------------------------------
 

--- a/tests/testthat/test-rand_forest-partykit.R
+++ b/tests/testthat/test-rand_forest-partykit.R
@@ -1,5 +1,26 @@
 library(testthat)
 
+# registration ------------------------------------------------------------
+
+test_that("engine is registered and translate() works", {
+  skip_if_not_installed("partykit")
+
+  engines <- parsnip::show_engines("rand_forest")
+  censored_engines <- engines$engine[engines$mode == "censored regression"]
+  expect_in("partykit", censored_engines)
+
+  spec <- rand_forest(trees = 100, min_n = 5) |>
+    set_engine("partykit") |>
+    set_mode("censored regression")
+
+  translated <- translate(spec)
+  expect_equal(translated$method$fit$func[["fun"]], "cforest_train")
+  expect_in(c("ntree", "minsplit"), names(translated$method$fit$args))
+  expect_equal(rlang::eval_tidy(translated$method$fit$args$ntree), 100)
+})
+
+# fit ---------------------------------------------------------------------
+
 test_that("model object", {
   skip_if_not_installed("partykit")
   skip_if_not_installed("coin")
@@ -214,6 +235,27 @@ test_that("`fix_xy()` works", {
     eval_time = c(100, 200)
   )
   expect_equal(f_pred_survival, xy_pred_survival)
+})
+
+# tuning ------------------------------------------------------------------
+
+test_that("tuning parameters are inherited", {
+  skip_if_not_installed("partykit")
+
+  spec <- rand_forest(mtry = tune(), trees = tune(), min_n = tune()) |>
+    set_engine(
+      "partykit",
+      mincriterion = tune(),
+      teststat = tune(),
+      testtype = tune()
+    ) |>
+    set_mode("censored regression")
+
+  params <- hardhat::extract_parameter_set_dials(spec)
+  expect_setequal(
+    params$name,
+    c("mtry", "trees", "min_n", "mincriterion", "teststat", "testtype")
+  )
 })
 
 # case weights ------------------------------------------------------------

--- a/tests/testthat/test-survival_reg-flexsurv.R
+++ b/tests/testthat/test-survival_reg-flexsurv.R
@@ -1,5 +1,25 @@
 library(testthat)
 
+# registration ------------------------------------------------------------
+
+test_that("engine is registered and translate() works", {
+  skip_if_not_installed("flexsurv")
+
+  engines <- parsnip::show_engines("survival_reg")
+  censored_engines <- engines$engine[engines$mode == "censored regression"]
+  expect_in("flexsurv", censored_engines)
+
+  spec <- survival_reg(dist = "weibull") |>
+    set_engine("flexsurv") |>
+    set_mode("censored regression")
+
+  translated <- translate(spec)
+  expect_equal(translated$method$fit$func[["fun"]], "flexsurvreg")
+  expect_equal(rlang::eval_tidy(translated$method$fit$args$dist), "weibull")
+})
+
+# fit ---------------------------------------------------------------------
+
 test_that("model object", {
   skip_if_not_installed("flexsurv")
 
@@ -457,6 +477,19 @@ test_that("`fix_xy()` works", {
     eval_time = c(100, 200)
   )
   expect_equal(f_pred_hazard, xy_pred_hazard)
+})
+
+# tuning ------------------------------------------------------------------
+
+test_that("tuning parameters are inherited", {
+  skip_if_not_installed("flexsurv")
+
+  spec <- survival_reg(dist = tune()) |>
+    set_engine("flexsurv") |>
+    set_mode("censored regression")
+
+  params <- hardhat::extract_parameter_set_dials(spec)
+  expect_setequal(params$name, "dist")
 })
 
 # case weights ------------------------------------------------------------

--- a/tests/testthat/test-survival_reg-flexsurvspline.R
+++ b/tests/testthat/test-survival_reg-flexsurvspline.R
@@ -1,5 +1,25 @@
 library(testthat)
 
+# registration ------------------------------------------------------------
+
+test_that("engine is registered and translate() works", {
+  skip_if_not_installed("flexsurv")
+
+  engines <- parsnip::show_engines("survival_reg")
+  censored_engines <- engines$engine[engines$mode == "censored regression"]
+  expect_in("flexsurvspline", censored_engines)
+
+  spec <- survival_reg() |>
+    set_engine("flexsurvspline", k = 2) |>
+    set_mode("censored regression")
+
+  translated <- translate(spec)
+  expect_equal(translated$method$fit$func[["fun"]], "flexsurvspline")
+  expect_equal(rlang::eval_tidy(translated$method$fit$args$k), 2)
+})
+
+# fit ---------------------------------------------------------------------
+
 test_that("model object", {
   skip_if_not_installed("flexsurv")
 
@@ -471,6 +491,19 @@ test_that("`fix_xy()` works", {
     eval_time = c(100, 200)
   )
   expect_equal(f_pred_hazard, xy_pred_hazard)
+})
+
+# tuning ------------------------------------------------------------------
+
+test_that("tuning parameters are inherited", {
+  skip_if_not_installed("flexsurv")
+
+  spec <- survival_reg() |>
+    set_engine("flexsurvspline", k = tune()) |>
+    set_mode("censored regression")
+
+  params <- hardhat::extract_parameter_set_dials(spec)
+  expect_setequal(params$name, "k")
 })
 
 # case weights ------------------------------------------------------------

--- a/tests/testthat/test-survival_reg-survival.R
+++ b/tests/testthat/test-survival_reg-survival.R
@@ -1,5 +1,23 @@
 library(testthat)
 
+# registration ------------------------------------------------------------
+
+test_that("engine is registered and translate() works", {
+  engines <- parsnip::show_engines("survival_reg")
+  censored_engines <- engines$engine[engines$mode == "censored regression"]
+  expect_in("survival", censored_engines)
+
+  spec <- survival_reg(dist = "weibull") |>
+    set_engine("survival") |>
+    set_mode("censored regression")
+
+  translated <- translate(spec)
+  expect_equal(translated$method$fit$func[["fun"]], "survreg")
+  expect_equal(rlang::eval_tidy(translated$method$fit$args$dist), "weibull")
+})
+
+# fit ---------------------------------------------------------------------
+
 test_that("model object", {
   set.seed(1234)
   exp_f_fit <- survival::survreg(
@@ -614,6 +632,17 @@ test_that("hazard_survreg() accepts eval_time values that it can handle", {
   expect_no_error(
     hazard_survreg(mod, new_data = new_data, eval_time = c(100, 100, 200))
   )
+})
+
+# tuning ------------------------------------------------------------------
+
+test_that("tuning parameters are inherited", {
+  spec <- survival_reg(dist = tune()) |>
+    set_engine("survival") |>
+    set_mode("censored regression")
+
+  params <- hardhat::extract_parameter_set_dials(spec)
+  expect_setequal(params$name, "dist")
 })
 
 # case weights ------------------------------------------------------------


### PR DESCRIPTION
This has surfaced tidymodels/parsnip#1398 and tidymodels/censored#395

Some other main arguments to the model spec function aren't tunable either but that's on purpose:

- `proportional_hazards()` with `survival`: `penalty` and `mixture` don't apply here, they are just for glmnet
- `decision_tree()` with `partykit`: `cost_complexity` isn't tunable because `ctree()` uses significance-based stopping, not cost-complexity pruning