### PR TITLE
Remove misleading test

### DIFF
--- a/tests/testthat/test-bag_tree-rpart.R
+++ b/tests/testthat/test-bag_tree-rpart.R
@@ -36,34 +36,6 @@ test_that("model object", {
   )
 })
 
-test_that("main args work without set_model_arg()", {
-  skip_if_not_installed("ipred")
-
-  set.seed(1234)
-  exp_f_fit <- ipred::bagging(
-    Surv(time, status) ~ age + ph.ecog,
-    data = lung,
-    # already part of translate?
-    maxdepth = 20,
-    minsplit = 10,
-    cp = 0.5
-  )
-
-  # formula method
-  mod_spec <- bag_tree(tree_depth = 20, min_n = 10, cost_complexity = 0.5) |>
-    set_mode("censored regression") |>
-    set_engine("rpart")
-  set.seed(1234)
-  f_fit <- fit(mod_spec, Surv(time, status) ~ age + ph.ecog, data = lung)
-
-  # Removing `call` element from both
-  expect_equal(
-    f_fit$fit[names(f_fit$fit) != "call"],
-    exp_f_fit[names(exp_f_fit) != "call"],
-    ignore_formula_env = TRUE
-  )
-})
-
 # prediction: time --------------------------------------------------------
 
 test_that("time predictions", {


### PR DESCRIPTION
The dev version of ipred fixes the bug discovered in #390 but now also breaks this test by now showing `maxdepth`, `minsplit`, and `cp` in the calls of the various `btree`s in the model fitted via ipred directly, while the corresponding calls from an object fitted via parsnip/censored do not.

Example:

```
── Failure (test-bag_tree-rpart.R:60:3): main args work without set_model_arg() ─────────────────────────────
Expected `f_fit$fit[names(f_fit$fit) != "call"]` to equal `exp_f_fit[names(exp_f_fit) != "call"]`.
Differences:
actual$mtrees[[1]]$btree$call[81:84] vs expected$mtrees[[1]]$btree$call[81:84]
  `"186.1", "50.3", "228", "90", "81.1", "74", "149", "12", "38", `
  `"82", "196.1", "48", "87.2", "167.1", "83", "95", "148.4", "147", `
  `"152.1", "108.1", "32", "6.1", "7", "73.3"), class = "data.frame"), `
- `    control = control)`
+ `    control = control, maxdepth = 20, minsplit = 10, cp = 0.5)`
```

That is because 
a) ipred now passes the dots correctly (so the arguments do show up now)
b) censored never passed the arguments correctly (see #406)

The test passed previous but for the wrong reasons
- the trees in the fitted model object were the same because we all used the rpart default values (not because anything got passed around properly)
- the calls were the same because neither irped nor censored passed it on correctly

So. I'm removing this test here because it's not a good test and we'll track the underlying issue in #406.

